### PR TITLE
feat: Ajoute la date du jour sur la page d'accueil

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -32,6 +32,13 @@ Types d'accès :
 
 **Résultat attendu** : la page s'affiche sans erreur, header et footer visibles.
 
+### NAV-03 [PUBLIC] — Affichage de la date du jour
+1. Ouvrir `${BASE_URL}/`
+2. Vérifier la présence d'un élément affichant la date du jour
+3. Vérifier que la date correspond au jour courant (format français, ex : « mercredi 9 avril 2025 »)
+
+**Résultat attendu** : la date du jour est affichée sur la page d'accueil au format français.
+
 ### NAV-02 [PUBLIC] — Navigation responsive
 1. Ouvrir `${BASE_URL}/` en viewport mobile
 2. Cliquer sur le menu burger

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,25 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
 export default function Home() {
+  const [today, setToday] = useState('');
+
+  useEffect(() => {
+    setToday(
+      new Date().toLocaleDateString('fr-FR', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    );
+  }, []);
+
   return (
     <main style={{ fontFamily: 'system-ui, sans-serif', padding: '2rem' }}>
       <h1>Hello, World!</h1>
+      {today && <p>Nous sommes le <time dateTime={new Date().toISOString().split('T')[0]}>{today}</time>.</p>}
       <p>Bienvenue sur <strong>culturall-website</strong> — Next.js 14 + Django/Wagtail.</p>
       <p>
         Backend : <a href="http://localhost:8000/">localhost:8000</a> ·{' '}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -4,22 +4,25 @@ import { useEffect, useState } from 'react';
 
 export default function Home() {
   const [today, setToday] = useState('');
+  const [todayISO, setTodayISO] = useState('');
 
   useEffect(() => {
+    const now = new Date();
     setToday(
-      new Date().toLocaleDateString('fr-FR', {
+      now.toLocaleDateString('fr-FR', {
         weekday: 'long',
         year: 'numeric',
         month: 'long',
         day: 'numeric',
       })
     );
+    setTodayISO(now.toISOString().split('T')[0]);
   }, []);
 
   return (
     <main style={{ fontFamily: 'system-ui, sans-serif', padding: '2rem' }}>
       <h1>Hello, World!</h1>
-      {today && <p>Nous sommes le <time dateTime={new Date().toISOString().split('T')[0]}>{today}</time>.</p>}
+      {today && <p>Nous sommes le <time dateTime={todayISO}>{today}</time>.</p>}
       <p>Bienvenue sur <strong>culturall-website</strong> — Next.js 14 + Django/Wagtail.</p>
       <p>
         Backend : <a href="http://localhost:8000/">localhost:8000</a> ·{' '}


### PR DESCRIPTION
## Description

Closes #1

Convertit le composant Home en Client Component pour afficher la date du jour formatée en français (`toLocaleDateString('fr-FR')`).

---

## Documentation

### Ce qui a été implémenté
- **`frontend/app/page.tsx`** : converti en Client Component (`'use client'`) avec `useEffect`/`useState` pour afficher la date du jour.

### Choix techniques
- `useEffect` pour éviter les erreurs d'hydration SSR/client.
- Format français complet : « mercredi 9 avril 2025 ».
- Balise sémantique `<time>` avec `dateTime` ISO pour l'accessibilité.

### Points d'attention
- Aucune dépendance externe ajoutée.
- Le composant Home est maintenant un Client Component.