### PR TITLE
feat: Ajout d'un formulaire de contact

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -5,6 +5,8 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
+from home.views import contact_submit
+
 
 def hello(request):
     return HttpResponse(
@@ -19,6 +21,9 @@ urlpatterns = [
     # HelloWorld root view — à remplacer par les pages Wagtail (voir plus bas)
     # quand un HomePage aura été créé.
     path("", hello),
+
+    # API
+    path("api/contact/", contact_submit, name="contact-submit"),
 
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),

--- a/backend/home/admin.py
+++ b/backend/home/admin.py
@@ -1,0 +1,18 @@
+from django.contrib import admin
+
+from .models import ContactSubmission
+
+
+@admin.register(ContactSubmission)
+class ContactSubmissionAdmin(admin.ModelAdmin):
+    list_display = ("subject", "name", "email", "created_at")
+    list_filter = ("created_at",)
+    search_fields = ("name", "email", "subject", "message")
+    readonly_fields = ("name", "email", "subject", "message", "created_at")
+    ordering = ("-created_at",)
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False

--- a/backend/home/migrations/0002_contactsubmission.py
+++ b/backend/home/migrations/0002_contactsubmission.py
@@ -1,0 +1,29 @@
+# Generated manually for issue #7
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('home', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ContactSubmission',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=150, verbose_name='Nom')),
+                ('email', models.EmailField(max_length=254, verbose_name='Email')),
+                ('subject', models.CharField(max_length=255, verbose_name='Sujet')),
+                ('message', models.TextField(verbose_name='Message')),
+                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Date de soumission')),
+            ],
+            options={
+                'verbose_name': 'Demande de contact',
+                'verbose_name_plural': 'Demandes de contact',
+                'ordering': ['-created_at'],
+            },
+        ),
+    ]

--- a/backend/home/models.py
+++ b/backend/home/models.py
@@ -11,8 +11,25 @@ basculer le routing racine sur Wagtail, lance :
 dans config/urls.py.
 """
 
+from django.db import models
 from wagtail.models import Page
 
 
 class HomePage(Page):
     pass
+
+
+class ContactSubmission(models.Model):
+    name = models.CharField("Nom", max_length=150)
+    email = models.EmailField("Email")
+    subject = models.CharField("Sujet", max_length=255)
+    message = models.TextField("Message")
+    created_at = models.DateTimeField("Date de soumission", auto_now_add=True)
+
+    class Meta:
+        verbose_name = "Demande de contact"
+        verbose_name_plural = "Demandes de contact"
+        ordering = ["-created_at"]
+
+    def __str__(self):
+        return f"{self.subject} — {self.name} ({self.created_at:%d/%m/%Y})"

--- a/backend/home/views.py
+++ b/backend/home/views.py
@@ -1,0 +1,43 @@
+import json
+
+from django.http import JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from .models import ContactSubmission
+
+
+@csrf_exempt
+@require_POST
+def contact_submit(request):
+    try:
+        data = json.loads(request.body)
+    except (json.JSONDecodeError, ValueError):
+        return JsonResponse({"error": "JSON invalide."}, status=400)
+
+    errors = {}
+    name = data.get("name", "").strip()
+    email = data.get("email", "").strip()
+    subject = data.get("subject", "").strip()
+    message = data.get("message", "").strip()
+
+    if not name:
+        errors["name"] = "Le nom est requis."
+    if not email:
+        errors["email"] = "L'email est requis."
+    if not subject:
+        errors["subject"] = "Le sujet est requis."
+    if not message:
+        errors["message"] = "Le message est requis."
+
+    if errors:
+        return JsonResponse({"errors": errors}, status=400)
+
+    ContactSubmission.objects.create(
+        name=name,
+        email=email,
+        subject=subject,
+        message=message,
+    )
+
+    return JsonResponse({"message": "Votre message a bien été envoyé."}, status=201)

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -46,9 +46,9 @@ Types d'accès :
 1. Ouvrir `${BASE_URL}/`
 2. Cliquer sur le lien « Contact » dans le header
 3. Vérifier que l'URL est `${BASE_URL}/contact`
-4. Vérifier que la page Contact s'affiche avec un titre
+4. Vérifier que la page Contact s'affiche avec un titre et un formulaire de contact
 
-**Résultat attendu** : navigation fonctionnelle vers la page Contact.
+**Résultat attendu** : navigation fonctionnelle vers la page Contact avec formulaire visible.
 
 ### NAV-04 [PUBLIC] — Header visible sur toutes les pages
 1. Ouvrir `${BASE_URL}/a-propos`
@@ -65,7 +65,44 @@ Types d'accès :
 
 **Résultat attendu** : la landing page et la navigation sont utilisables sur mobile.
 
-## 2. Authentification
+## 2. Formulaire de contact
+
+### CONTACT-01 [PUBLIC] — Affichage du formulaire de contact
+1. Ouvrir `${BASE_URL}/contact`
+2. Vérifier la présence d'un formulaire avec les champs : Nom, Email, Sujet, Message
+3. Vérifier la présence d'un bouton d'envoi
+4. Vérifier que les champs sont vides par défaut
+
+**Résultat attendu** : le formulaire de contact s'affiche avec tous les champs attendus.
+
+### CONTACT-02 [PUBLIC] — Soumission du formulaire avec succès
+1. Ouvrir `${BASE_URL}/contact`
+2. Remplir le champ Nom avec « Test Utilisateur »
+3. Remplir le champ Email avec « test@example.com »
+4. Remplir le champ Sujet avec « Demande de test »
+5. Remplir le champ Message avec « Ceci est un message de test. »
+6. Cliquer sur le bouton d'envoi
+7. Vérifier qu'un message de confirmation s'affiche (ex : « Votre message a bien été envoyé »)
+
+**Résultat attendu** : le formulaire est soumis, un message de succès s'affiche, les champs sont réinitialisés.
+
+### CONTACT-03 [PUBLIC] — Validation des champs obligatoires
+1. Ouvrir `${BASE_URL}/contact`
+2. Cliquer sur le bouton d'envoi sans remplir les champs
+3. Vérifier qu'un message d'erreur s'affiche pour les champs requis
+
+**Résultat attendu** : le formulaire n'est pas soumis, des messages d'erreur de validation sont visibles.
+
+### CONTACT-04 [AUTH] — Visibilité des soumissions dans l'admin Django
+1. Soumettre un formulaire de contact via `${BASE_URL}/contact` (cf. CONTACT-02)
+2. Ouvrir `${BASE_URL}/django-admin/`
+3. Se connecter avec les identifiants admin
+4. Naviguer vers la section « Demandes de contact » (ou « Contact submissions »)
+5. Vérifier que la soumission apparaît dans la liste avec les bonnes données
+
+**Résultat attendu** : la soumission de contact est visible dans l'admin Django avec toutes les informations saisies.
+
+## 3. Authentification
 
 ### AUTH-01 [PUBLIC] — Connexion utilisateur valide
 1. Ouvrir `${BASE_URL}/admin/login/`
@@ -81,7 +118,7 @@ Types d'accès :
 
 **Résultat attendu** : session terminée, accès aux pages [AUTH] redirigé vers la connexion.
 
-## 3. Parcours principal
+## 4. Parcours principal
 
 ### E2E-01 [AUTH] — Parcours end-to-end principal
 1. Se connecter

--- a/frontend/app/contact/ContactForm.tsx
+++ b/frontend/app/contact/ContactForm.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+
+interface FormData {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
+interface FormErrors {
+  name?: string;
+  email?: string;
+  subject?: string;
+  message?: string;
+}
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+
+export default function ContactForm() {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    email: '',
+    subject: '',
+    message: '',
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [success, setSuccess] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ) {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    if (errors[name as keyof FormErrors]) {
+      setErrors((prev) => ({ ...prev, [name]: undefined }));
+    }
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setErrors({});
+    setSuccess(false);
+    setSubmitting(true);
+
+    try {
+      const res = await fetch(`${API_URL}/api/contact/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+
+      if (res.ok) {
+        setSuccess(true);
+        setFormData({ name: '', email: '', subject: '', message: '' });
+      } else {
+        const body = await res.json();
+        if (body.errors) {
+          setErrors(body.errors);
+        } else if (body.error) {
+          setErrors({ name: body.error });
+        }
+      }
+    } catch {
+      setErrors({ name: 'Une erreur est survenue. Veuillez réessayer.' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form className="contact-form" onSubmit={handleSubmit} noValidate>
+      {success && (
+        <p className="contact-success">Votre message a bien été envoyé.</p>
+      )}
+
+      <div className="contact-field">
+        <label htmlFor="name">Nom</label>
+        <input
+          id="name"
+          name="name"
+          type="text"
+          value={formData.name}
+          onChange={handleChange}
+          required
+        />
+        {errors.name && <span className="contact-error">{errors.name}</span>}
+      </div>
+
+      <div className="contact-field">
+        <label htmlFor="email">Email</label>
+        <input
+          id="email"
+          name="email"
+          type="email"
+          value={formData.email}
+          onChange={handleChange}
+          required
+        />
+        {errors.email && <span className="contact-error">{errors.email}</span>}
+      </div>
+
+      <div className="contact-field">
+        <label htmlFor="subject">Sujet</label>
+        <input
+          id="subject"
+          name="subject"
+          type="text"
+          value={formData.subject}
+          onChange={handleChange}
+          required
+        />
+        {errors.subject && (
+          <span className="contact-error">{errors.subject}</span>
+        )}
+      </div>
+
+      <div className="contact-field">
+        <label htmlFor="message">Message</label>
+        <textarea
+          id="message"
+          name="message"
+          rows={6}
+          value={formData.message}
+          onChange={handleChange}
+          required
+        />
+        {errors.message && (
+          <span className="contact-error">{errors.message}</span>
+        )}
+      </div>
+
+      <button type="submit" className="contact-submit" disabled={submitting}>
+        {submitting ? 'Envoi en cours…' : 'Envoyer'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/app/contact/page.tsx
+++ b/frontend/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import ContactForm from './ContactForm';
 
 export const metadata: Metadata = {
   title: 'Contact',
@@ -11,6 +12,7 @@ export default function Contact() {
       <p>
         Pour toute question ou proposition, n&apos;hésitez pas à nous contacter.
       </p>
+      <ContactForm />
     </main>
   );
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -97,3 +97,80 @@ body {
   opacity: 0.85;
   line-height: 1.7;
 }
+
+/* Contact form */
+.contact-form {
+  max-width: 640px;
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.contact-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.contact-field label {
+  font-size: 0.95rem;
+  font-weight: 500;
+  opacity: 0.9;
+}
+
+.contact-field input,
+.contact-field textarea {
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: #fff;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 6px;
+  transition: border-color 0.2s;
+}
+
+.contact-field input:focus,
+.contact-field textarea:focus {
+  outline: none;
+  border-color: #666;
+}
+
+.contact-field textarea {
+  resize: vertical;
+}
+
+.contact-error {
+  font-size: 0.85rem;
+  color: #f87171;
+}
+
+.contact-success {
+  padding: 0.75rem 1rem;
+  background: #166534;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.contact-submit {
+  align-self: flex-start;
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #000;
+  background: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.contact-submit:hover {
+  opacity: 0.85;
+}
+
+.contact-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}


### PR DESCRIPTION
## Description

Closes #7

Ajout d'un formulaire de contact dans la section contact du site, avec persistance des soumissions en base de données et visibilité dans l'admin Django.

---

## Documentation

### Ce qui a été implémenté

**Backend Django :**
- **Modèle `ContactSubmission`** (`backend/home/models.py`) : champs nom, email, sujet, message, date de soumission. Ordonné par date décroissante.
- **Migration** (`backend/home/migrations/0002_contactsubmission.py`) : crée la table en base.
- **Admin Django** (`backend/home/admin.py`) : enregistrement en lecture seule avec `list_display`, filtres par date, recherche sur tous les champs. Ajout et modification désactivés (consultation uniquement).
- **Vue API** (`backend/home/views.py`) : endpoint `POST /api/contact/` qui valide les 4 champs obligatoires et crée l'entrée en base. Retourne JSON avec message de succès (201) ou erreurs de validation (400).
- **Route** (`backend/config/urls.py`) : ajout de `path("api/contact/", ...)`.

**Frontend Next.js :**
- **Composant `ContactForm`** (`frontend/app/contact/ContactForm.tsx`) : formulaire React client-side avec gestion d'état (useState), validation côté serveur, message de succès, réinitialisation après envoi.
- **Page contact** (`frontend/app/contact/page.tsx`) : intègre le composant `ContactForm`.
- **Styles** (`frontend/app/globals.css`) : classes `.contact-form`, `.contact-field`, `.contact-error`, `.contact-success`, `.contact-submit` — cohérentes avec le design existant (fond sombre, texte blanc).

### Choix techniques
- **API sans DRF** : endpoint Django natif (json.loads + JsonResponse) pour éviter d'ajouter une dépendance. Suffisant pour un seul endpoint POST simple.
- **`@csrf_exempt`** : nécessaire car le frontend Next.js est un client séparé (pas de cookie CSRF Django). La protection CSRF n'est pas applicable dans cette architecture découplée.
- **Admin en lecture seule** : les soumissions de contact ne doivent pas être créées/modifiées manuellement.

### Comment utiliser
- **Soumission** : remplir le formulaire sur `/contact` et cliquer « Envoyer »
- **Consultation admin** : accéder à `/django-admin/` → « Demandes de contact »
- **API directe** : `POST /api/contact/` avec body JSON `{"name", "email", "subject", "message"}`

### Points d'attention
- Exécuter `python manage.py migrate` pour créer la table `home_contactsubmission`
- L'endpoint est `@csrf_exempt` — acceptable dans l'architecture découplée front/back
- Pas de rate-limiting sur l'endpoint (à envisager si besoin anti-spam)