### PR TITLE
feat: add association logo to header

### DIFF
--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -1,10 +1,18 @@
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default function Header() {
   return (
     <header className="header">
-      <Link href="/" className="header-title">
-        Cultur&apos;all
+      <Link href="/" className="header-logo" aria-label="Cultur'all - Accueil">
+        <Image
+          src="/logo.png"
+          alt="Cultur'all"
+          width={160}
+          height={60}
+          priority
+          className="header-logo-img"
+        />
       </Link>
       <nav className="header-nav">
         <Link href="/a-propos">À propos</Link>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -24,12 +24,18 @@ body {
   z-index: 10;
 }
 
-.header-title {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: #fff;
+.header-logo {
+  display: inline-flex;
+  align-items: center;
   text-decoration: none;
-  letter-spacing: 0.02em;
+  line-height: 0;
+}
+
+.header-logo-img {
+  height: auto;
+  width: auto;
+  max-height: 60px;
+  display: block;
 }
 
 .header-nav {


### PR DESCRIPTION
Replace the text title in the header with the Cultur'all logo image using next/image. The logo is displayed in the top-left corner and links to the homepage.

The actual logo file must be placed at frontend/public/logo.png.

https://claude.ai/code/session_01GXekhQDCyZmFn78zWcz1vt