### PR TITLE
feat: ajout miniature pour les projets

### DIFF
--- a/backend/projects/migrations/0002_project_thumbnail.py
+++ b/backend/projects/migrations/0002_project_thumbnail.py
@@ -1,0 +1,25 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailimages", "0026_delete_uploadedimage"),
+        ("projects", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="project",
+            name="thumbnail",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailimages.image",
+                verbose_name="Miniature",
+            ),
+        ),
+    ]

--- a/backend/projects/models.py
+++ b/backend/projects/models.py
@@ -4,6 +4,7 @@ from modelcluster.models import ClusterableModel
 from modelcluster.tags import ClusterTaggableManager
 from taggit.models import TaggedItemBase
 from wagtail.admin.panels import FieldPanel
+from wagtail.images import get_image_model_string
 from wagtail.snippets.models import register_snippet
 
 
@@ -25,6 +26,14 @@ class Project(ClusterableModel):
         blank=True,
         verbose_name="Tags",
     )
+    thumbnail = models.ForeignKey(
+        get_image_model_string(),
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+        verbose_name="Miniature",
+    )
     created_at = models.DateTimeField(auto_now_add=True)
 
     panels = [
@@ -32,6 +41,7 @@ class Project(ClusterableModel):
         FieldPanel("description"),
         FieldPanel("tags"),
         FieldPanel("youtube_url"),
+        FieldPanel("thumbnail"),
     ]
 
     class Meta:

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -7,7 +7,7 @@ from .models import Project
 @require_GET
 def project_list(request):
     """Return all projects as JSON."""
-    projects = Project.objects.prefetch_related("tags").all()
+    projects = Project.objects.prefetch_related("tags").select_related("thumbnail").all()
     data = [
         {
             "id": project.pk,
@@ -15,6 +15,13 @@ def project_list(request):
             "description": project.description,
             "youtube_url": project.youtube_url,
             "tags": [tag.name for tag in project.tags.all()],
+            "thumbnail_url": (
+                request.build_absolute_uri(
+                    project.thumbnail.get_rendition("fill-600x400").url
+                )
+                if project.thumbnail
+                else None
+            ),
         }
         for project in projects
     ]

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -92,12 +92,13 @@ Types d'accès :
 
 **Résultat attendu** : l'overlay s'ouvre avec une animation fluide, les cartes de projets sont visibles.
 
-### PROJ-02 [PUBLIC] — Affichage des cartes de projets
+### PROJ-02 [PUBLIC] — Affichage des cartes de projets avec miniature
 1. Ouvrir l'overlay Nos Projets (cliquer sur « Nos Projets » dans le header)
-2. Vérifier que chaque carte affiche le titre au centre et le type (tag) au milieu
-3. Vérifier que les cartes ont des bords arrondis
+2. Vérifier que chaque carte affiche une image miniature en fond
+3. Vérifier que le titre et le type (tag) sont masqués par défaut (non visibles sur la carte au repos)
+4. Vérifier que les cartes ont des bords arrondis et une taille augmentée
 
-**Résultat attendu** : les cartes de projets affichent titre et type avec le style attendu.
+**Résultat attendu** : les cartes de projets affichent la miniature en fond, le titre et le tag sont masqués au repos.
 
 ### PROJ-03 [PUBLIC] — Ouverture d'un projet en vue détail
 1. Ouvrir l'overlay Nos Projets
@@ -124,17 +125,27 @@ Types d'accès :
 
 **Résultat attendu** : l'overlay se ferme proprement et la landing page revient à l'état normal.
 
-### PROJ-06 [AUTH] — Ajout d'un projet via l'admin Wagtail
+### PROJ-06 [AUTH] — Ajout d'un projet avec miniature via l'admin Wagtail
 1. Se connecter à `${BASE_URL}/admin/`
 2. Naviguer vers la section Snippets > Projets
 3. Cliquer sur « Ajouter »
 4. Remplir titre, description, tags (ex: « Clip »), lien YouTube
-5. Sauvegarder
-6. Vérifier que le projet apparaît dans la liste admin
-7. Ouvrir l'overlay Nos Projets côté public
-8. Vérifier que le nouveau projet apparaît
+5. Ajouter une miniature via le sélecteur d'images Wagtail
+6. Sauvegarder
+7. Vérifier que le projet apparaît dans la liste admin
+8. Ouvrir l'overlay Nos Projets côté public
+9. Vérifier que le nouveau projet apparaît avec sa miniature en fond de carte
 
-**Résultat attendu** : le projet est créé via l'admin et visible côté public.
+**Résultat attendu** : le projet est créé via l'admin avec miniature et visible côté public avec l'image en fond de carte.
+
+### PROJ-07 [PUBLIC] — Effet hover sur les cartes de projets
+1. Ouvrir l'overlay Nos Projets (cliquer sur « Nos Projets » dans le header)
+2. Passer la souris sur une carte de projet
+3. Vérifier que l'image de fond se floute (effet blur)
+4. Vérifier que l'image de fond s'assombrit
+5. Vérifier que le titre et le type (tag) du projet apparaissent au centre de la carte
+
+**Résultat attendu** : au survol, l'image se floute et s'assombrit, le titre et le tag apparaissent avec une transition fluide.
 
 ## 4. Parcours principal
 

--- a/frontend/app/components/ProjectsOverlay.tsx
+++ b/frontend/app/components/ProjectsOverlay.tsx
@@ -8,6 +8,7 @@ interface Project {
   description: string;
   youtube_url: string;
   tags: string[];
+  thumbnail_url: string | null;
 }
 
 function extractYouTubeId(url: string): string | null {
@@ -122,6 +123,14 @@ export default function ProjectsOverlay({ open, onClose }: ProjectsOverlayProps)
                   className="project-card"
                   onClick={() => handleSelectProject(project)}
                 >
+                  {project.thumbnail_url && (
+                    <img
+                      src={project.thumbnail_url}
+                      alt=""
+                      className="project-card__thumbnail"
+                    />
+                  )}
+                  <div className="project-card__overlay" />
                   <span className="project-card__tag">
                     {project.tags[0] || ''}
                   </span>

--- a/frontend/app/components/ProjectsOverlay.tsx
+++ b/frontend/app/components/ProjectsOverlay.tsx
@@ -120,17 +120,19 @@ export default function ProjectsOverlay({ open, onClose }: ProjectsOverlayProps)
               {projects.map((project) => (
                 <button
                   key={project.id}
-                  className="project-card"
+                  className={`project-card ${!project.thumbnail_url ? 'project-card--no-thumbnail' : ''}`}
                   onClick={() => handleSelectProject(project)}
                 >
                   {project.thumbnail_url && (
-                    <img
-                      src={project.thumbnail_url}
-                      alt=""
-                      className="project-card__thumbnail"
-                    />
+                    <>
+                      <img
+                        src={project.thumbnail_url}
+                        alt=""
+                        className="project-card__thumbnail"
+                      />
+                      <div className="project-card__overlay" />
+                    </>
                   )}
-                  <div className="project-card__overlay" />
                   <span className="project-card__tag">
                     {project.tags[0] || ''}
                   </span>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -165,42 +165,89 @@ body {
 
 .projects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: 1.5rem;
 }
 
 /* Project card */
 .project-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: 0.75rem;
+  min-height: 280px;
   padding: 2.5rem 1.5rem;
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 1rem;
   cursor: pointer;
-  transition: transform 0.3s ease, background 0.3s ease;
+  overflow: hidden;
+  transition: transform 0.3s ease;
   color: #fff;
   font-family: inherit;
 }
 
 .project-card:hover {
   transform: scale(1.04);
-  background: rgba(255, 255, 255, 0.14);
 }
 
+/* Thumbnail image as background */
+.project-card__thumbnail {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: filter 0.4s ease;
+  z-index: 0;
+}
+
+/* Dark overlay — appears on hover */
+.project-card__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  z-index: 1;
+}
+
+.project-card:hover .project-card__thumbnail {
+  filter: blur(4px);
+}
+
+.project-card:hover .project-card__overlay {
+  opacity: 1;
+}
+
+/* Tag and title — hidden by default, appear on hover */
 .project-card__tag {
+  position: relative;
+  z-index: 2;
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  opacity: 0.7;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
 }
 
 .project-card__title {
+  position: relative;
+  z-index: 2;
   font-size: 1.25rem;
   font-weight: 600;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.4s ease 0.05s, transform 0.4s ease 0.05s;
+}
+
+.project-card:hover .project-card__tag,
+.project-card:hover .project-card__title {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 /* Project detail */

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -250,6 +250,21 @@ body {
   transform: translateY(0);
 }
 
+/* Cards without thumbnail — show tag and title normally */
+.project-card--no-thumbnail .project-card__tag,
+.project-card--no-thumbnail .project-card__title {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.project-card--no-thumbnail .project-card__tag {
+  opacity: 0.7;
+}
+
+.project-card--no-thumbnail:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
 /* Project detail */
 .project-detail {
   position: fixed;


### PR DESCRIPTION
## Description

Closes #9

Ajout de miniatures aux projets. Les cartes de la liste affichent l'image en fond. Au hover : blur + assombrissement + apparition du titre et du tag. Taille des cartes augmentée.

---

## Documentation

**Backend :**
- `backend/projects/models.py` : champ `thumbnail` (ForeignKey Wagtail Image, nullable)
- `backend/projects/migrations/0002_project_thumbnail.py` : migration
- `backend/projects/views.py` : API expose `thumbnail_url` (rendition `fill-600x400`)

**Frontend :**
- `frontend/app/components/ProjectsOverlay.tsx` : image en fond de carte + overlay + titre/tag au hover
- `frontend/app/globals.css` : cartes agrandies, effet hover blur/darken/apparition

**Choix techniques :**
- Rendition `fill-600x400` pour un crop centré optimisé
- `request.build_absolute_uri()` pour URLs compatibles dev et prod
- Thumbnail optionnel : projets sans miniature restent fonctionnels

**Migration :** `python manage.py migrate projects`