### PR TITLE
fix: close #12 - Images non affichées en développement

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,3 +1,5 @@
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.http import HttpResponse
 from django.urls import include, path
@@ -37,3 +39,6 @@ urlpatterns = [
     # Décommente quand un HomePage existe et retire la route `hello` ci-dessus.
     # path("", include(wagtail_urls)),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Description

Closes #12

Les images uploadées via l'admin Wagtail ne s'affichaient nulle part (ni dans l'admin, ni en miniature sur les cartes projet). La cause : Django ne servait pas les fichiers media en mode développement car la configuration `static()` manquait dans `urls.py`.

---

## Documentation

### Ce qui a été implémenté
- **`backend/config/urls.py`** : ajout de `static(MEDIA_URL, document_root=MEDIA_ROOT)` conditionné par `DEBUG=True`

### Cause racine
Sans cette configuration, le serveur de développement Django retournait 404 pour toute requête `/media/*`. Les images étaient bien uploadées sur le disque via Wagtail, mais jamais servies au navigateur.

### Choix techniques
- Le bloc `if settings.DEBUG` garantit que cette route n'est active qu'en développement
- Pattern standard Django recommandé dans la documentation officielle
- Les environnements preprod (nginx) et prod (MinIO/S3) ne sont pas impactés

### Tests browser prévus
- PROJ-02 : Affichage des cartes de projets avec miniature
- PROJ-06 : Ajout d'un projet avec miniature via l'admin Wagtail