### PR TITLE
fix: images non affichées en prod

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -25,6 +25,7 @@ services:
       - MINIO_ROOT_PASSWORD
       - MINIO_ENDPOINT_URL
       - MINIO_BUCKET_NAME
+      - MINIO_PUBLIC_URL
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Description

Closes #14

La variable d'environnement `MINIO_PUBLIC_URL` n'était pas passée au container Django dans `docker-compose.base.yml`. En production, `production.py` utilise cette variable pour construire le `custom_domain` de django-storages S3Storage. Sans elle, les URLs d'images étaient cassées (`https:///media/...` au lieu de `https://media.culturall-website.nickorp.com/media/...`).

---

## Documentation

### Modification
- **`docker-compose.base.yml`** : ajout de `MINIO_PUBLIC_URL` dans l'environnement du service `django`

### Choix techniques
La variable était déjà documentée dans `.env.example` et utilisée dans `production.py`, mais jamais transmise au container Docker. Fix minimal d'une ligne.

### Comment vérifier
1. S'assurer que `MINIO_PUBLIC_URL=https://media.culturall-website.nickorp.com` est dans `.env.prod`
2. Redéployer
3. Vérifier que les miniatures des projets s'affichent côté public

### Points d'attention
- Aucune migration, aucun changement de code applicatif
- La variable doit exister dans `.env.prod` sur le serveur