### PR TITLE
feat: menu responsive

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -58,12 +58,16 @@ Types d'accès :
 
 **Résultat attendu** : le header est présent et fonctionnel sur toutes les pages.
 
-### NAV-05 [PUBLIC] — Navigation responsive
-1. Ouvrir `${BASE_URL}/` en viewport mobile (375px)
-2. Vérifier que le header reste visible et lisible
-3. Vérifier que les liens de navigation sont accessibles
+### NAV-05 [PUBLIC] — Navigation responsive (menu vertical sous le titre)
+1. Ouvrir `${BASE_URL}/` en viewport mobile (375px de large)
+2. Vérifier que le header s'affiche en disposition verticale (titre au-dessus, navigation en dessous)
+3. Vérifier que le titre « Cultur'all » est centré ou aligné
+4. Vérifier que les liens de navigation (« Nos Projets », « À propos », « Contact ») sont disposés verticalement sous le titre
+5. Vérifier que chaque lien de navigation est cliquable et fonctionne
+6. Naviguer vers `${BASE_URL}/a-propos` et vérifier que le header responsive est identique
+7. Naviguer vers `${BASE_URL}/contact` et vérifier que le header responsive est identique
 
-**Résultat attendu** : la landing page et la navigation sont utilisables sur mobile.
+**Résultat attendu** : sur mobile, le menu apparaît à la verticale en dessous du titre du site, tous les liens restent fonctionnels.
 
 ## 2. Formulaire de contact
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -435,6 +435,23 @@ body {
 
 /* Responsive */
 @media (max-width: 768px) {
+  .header {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 1rem 1.5rem;
+  }
+
+  .header-nav {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .page {
+    padding-top: 10rem;
+  }
+
   .project-detail__content {
     flex-direction: column;
     padding: 0 1.5rem 2rem;


### PR DESCRIPTION
## Description

Closes #15

Ajout de styles CSS responsive pour que le menu de navigation apparaisse à la verticale sous le titre du site sur les écrans mobiles (≤768px).

---

## Documentation

### Ce qui a été implémenté
- **`frontend/app/globals.css`** : ajout de styles responsive dans la media query `@media (max-width: 768px)` pour le header et la navigation

### Choix techniques
- **Approche CSS pure** : `flex-direction: column` sur `.header` et `.header-nav` pour empiler les éléments verticalement
- **`align-items: center`** pour centrer le titre et les liens
- **`padding-top: 10rem`** sur `.page` en mobile pour compenser la hauteur du header fixe

### Points d'attention
- Pas de hamburger menu : tous les liens restent visibles en permanence
- Le header reste en `position: fixed`