### PR TITLE
fix: close #18 - fix contact form submission error

### DIFF
--- a/frontend/app/contact/ContactForm.tsx
+++ b/frontend/app/contact/ContactForm.tsx
@@ -16,7 +16,7 @@ interface FormErrors {
   message?: string;
 }
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 export default function ContactForm() {
   const [formData, setFormData] = useState<FormData>({


### PR DESCRIPTION
## Description

Closes #18

Le formulaire de contact utilisait `http://localhost:8000` comme fallback pour `NEXT_PUBLIC_API_URL` quand la variable n'est pas définie au build time. En production, le JS client tentait d'envoyer les requêtes vers `localhost:8000` (inaccessible depuis le navigateur), provoquant une erreur réseau.

**Correction :** Aligner le fallback sur le pattern de `ProjectsOverlay.tsx` (chaîne vide = URL relative), compatible avec le routage Traefik en production.

---

## Documentation

### Fichiers modifiés
- `frontend/app/contact/ContactForm.tsx` : fallback `'http://localhost:8000'` → `''`

### Choix technique
En production, Traefik route `/api/*` vers Django (priorité 100). Une URL relative `/api/contact/` fonctionne nativement. En dev, `NEXT_PUBLIC_API_URL` est injecté via `.env.dev`, le fallback n'est jamais utilisé.