### PR TITLE
feat: landing page mobile - titre haut gauche, menu bas droite

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -58,16 +58,15 @@ Types d'accès :
 
 **Résultat attendu** : le header est présent et fonctionnel sur toutes les pages.
 
-### NAV-05 [PUBLIC] — Navigation responsive (menu vertical sous le titre)
+### NAV-05 [PUBLIC] — Navigation responsive (titre en haut à gauche, menu en bas à droite)
 1. Ouvrir `${BASE_URL}/` en viewport mobile (375px de large)
-2. Vérifier que le header s'affiche en disposition verticale (titre au-dessus, navigation en dessous)
-3. Vérifier que le titre « Cultur'all » est centré ou aligné
-4. Vérifier que les liens de navigation (« Nos Projets », « À propos », « Contact ») sont disposés verticalement sous le titre
-5. Vérifier que chaque lien de navigation est cliquable et fonctionne
-6. Naviguer vers `${BASE_URL}/a-propos` et vérifier que le header responsive est identique
-7. Naviguer vers `${BASE_URL}/contact` et vérifier que le header responsive est identique
+2. Vérifier que le titre « Cultur'all » est positionné en haut à gauche de l'écran
+3. Vérifier que les liens de navigation (« Nos Projets », « À propos », « Contact ») sont disposés verticalement en bas à droite de l'écran
+4. Vérifier que chaque lien de navigation est cliquable et fonctionne
+5. Naviguer vers `${BASE_URL}/a-propos` et vérifier que le header responsive est identique
+6. Naviguer vers `${BASE_URL}/contact` et vérifier que le header responsive est identique
 
-**Résultat attendu** : sur mobile, le menu apparaît à la verticale en dessous du titre du site, tous les liens restent fonctionnels.
+**Résultat attendu** : sur mobile, le titre est en haut à gauche, le menu apparaît à la verticale en bas à droite, tous les liens restent fonctionnels.
 
 ## 2. Formulaire de contact
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -436,20 +436,32 @@ body {
 /* Responsive */
 @media (max-width: 768px) {
   .header {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     flex-direction: column;
-    align-items: center;
-    gap: 0.75rem;
+    justify-content: space-between;
+    align-items: stretch;
     padding: 1rem 1.5rem;
+    pointer-events: none;
+  }
+
+  .header-title {
+    align-self: flex-start;
+    pointer-events: auto;
   }
 
   .header-nav {
     flex-direction: column;
-    align-items: center;
+    align-items: flex-end;
     gap: 0.75rem;
+    pointer-events: auto;
   }
 
   .page {
-    padding-top: 10rem;
+    padding-top: 5rem;
   }
 
   .project-detail__content {


### PR DESCRIPTION
## Description

Closes #19

Refonte du layout mobile du header pour positionner le titre du site en haut à gauche et le menu de navigation en bas à droite à la verticale.

---

## Documentation

### Fichiers modifiés
- **`frontend/app/globals.css`** : media query mobile (max-width: 768px) revu

### Approche
- Header en `position: fixed` couvrant tout le viewport avec `pointer-events: none`
- Titre en haut à gauche, navigation en bas à droite via flexbox column + `justify-content: space-between`
- `pointer-events: auto` sur le titre et la nav pour garder les clics fonctionnels
- Padding-top des pages intérieures ajusté (10rem → 5rem)

### Tests browser prévus
- NAV-05 : layout mobile titre/menu
- NAV-01 : régression landing page