### PR TITLE
feat: texte riche pour la description des projets

### DIFF
--- a/backend/projects/migrations/0003_rich_text_description.py
+++ b/backend/projects/migrations/0003_rich_text_description.py
@@ -1,0 +1,19 @@
+import wagtail.fields
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects", "0002_project_thumbnail"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="project",
+            name="description",
+            field=wagtail.fields.RichTextField(
+                blank=True, verbose_name="Description"
+            ),
+        ),
+    ]

--- a/backend/projects/models.py
+++ b/backend/projects/models.py
@@ -4,6 +4,7 @@ from modelcluster.models import ClusterableModel
 from modelcluster.tags import ClusterTaggableManager
 from taggit.models import TaggedItemBase
 from wagtail.admin.panels import FieldPanel
+from wagtail.fields import RichTextField
 from wagtail.images import get_image_model_string
 from wagtail.snippets.models import register_snippet
 
@@ -19,7 +20,7 @@ class ProjectTag(TaggedItemBase):
 @register_snippet
 class Project(ClusterableModel):
     title = models.CharField("Titre", max_length=255)
-    description = models.TextField("Description", blank=True)
+    description = RichTextField("Description", blank=True)
     youtube_url = models.URLField("Lien YouTube")
     tags = ClusterTaggableManager(
         through=ProjectTag,

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1,5 +1,6 @@
 from django.http import JsonResponse
 from django.views.decorators.http import require_GET
+from wagtail.rich_text import expand_db_html
 
 from .models import Project
 
@@ -12,7 +13,7 @@ def project_list(request):
         {
             "id": project.pk,
             "title": project.title,
-            "description": project.description,
+            "description": expand_db_html(project.description) if project.description else "",
             "youtube_url": project.youtube_url,
             "tags": [tag.name for tag in project.tags.all()],
             "thumbnail_url": (

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -144,11 +144,21 @@ Types d'accès :
 1. Ouvrir l'overlay Nos Projets
 2. Cliquer sur une carte de projet
 3. Vérifier que la carte s'agrandit en plein écran avec une transition progressive
-4. Vérifier qu'à gauche s'affichent les informations textuelles (titre, description, tags)
+4. Vérifier qu'à gauche s'affichent les informations textuelles (titre, description en texte riche, tags)
 5. Vérifier qu'à droite s'affiche la vidéo YouTube intégrée
 6. Vérifier la présence du lien « Retour aux projets » en haut
 
-**Résultat attendu** : la vue détail s'ouvre en plein écran avec les informations et la vidéo.
+**Résultat attendu** : la vue détail s'ouvre en plein écran avec les informations (description en texte riche formaté) et la vidéo.
+
+### PROJ-11 [PUBLIC] — Rendu du texte riche dans la description d'un projet
+1. Ouvrir l'overlay Nos Projets
+2. Cliquer sur un projet dont la description contient du texte riche (gras, italique, liste à puces, lien)
+3. Vérifier que le texte en gras s'affiche en **gras** (balise `<b>` ou `<strong>`)
+4. Vérifier que le texte en italique s'affiche en *italique* (balise `<i>` ou `<em>`)
+5. Vérifier que les listes à puces sont rendues sous forme de liste HTML (`<ul><li>`)
+6. Vérifier que les liens sont cliquables et s'ouvrent dans un nouvel onglet
+
+**Résultat attendu** : la description du projet affiche correctement le formatage riche (gras, italique, listes, liens).
 
 ### PROJ-04 [PUBLIC] — Retour depuis la vue détail vers la liste
 1. Ouvrir un projet en vue détail
@@ -165,18 +175,20 @@ Types d'accès :
 
 **Résultat attendu** : l'overlay se ferme proprement et la landing page revient à l'état normal.
 
-### PROJ-06 [AUTH] — Ajout d'un projet avec miniature via l'admin Wagtail
+### PROJ-06 [AUTH] — Ajout d'un projet avec miniature et description riche via l'admin Wagtail
 1. Se connecter à `${BASE_URL}/admin/`
 2. Naviguer vers la section Snippets > Projets
 3. Cliquer sur « Ajouter »
-4. Remplir titre, description, tags (ex: « Clip »), lien YouTube
-5. Ajouter une miniature via le sélecteur d'images Wagtail
-6. Sauvegarder
-7. Vérifier que le projet apparaît dans la liste admin
-8. Ouvrir l'overlay Nos Projets côté public
-9. Vérifier que le nouveau projet apparaît avec sa miniature en fond de carte
+4. Remplir titre, tags (ex: « Clip »), lien YouTube
+5. Dans le champ description, vérifier la présence d'un éditeur de texte riche (barre d'outils avec gras, italique, listes, liens…)
+6. Saisir du texte avec mise en forme : un mot en **gras**, un mot en *italique*, une liste à puces
+7. Ajouter une miniature via le sélecteur d'images Wagtail
+8. Sauvegarder
+9. Vérifier que le projet apparaît dans la liste admin
+10. Ouvrir l'overlay Nos Projets côté public
+11. Vérifier que le nouveau projet apparaît avec sa miniature en fond de carte
 
-**Résultat attendu** : le projet est créé via l'admin avec miniature et visible côté public avec l'image en fond de carte.
+**Résultat attendu** : le projet est créé via l'admin avec miniature, la description est saisie via un éditeur riche, et le projet est visible côté public avec l'image en fond de carte.
 
 ### PROJ-07 [PUBLIC] — Effet hover sur les cartes de projets
 1. Ouvrir l'overlay Nos Projets (cliquer sur « Nos Projets » dans le header)

--- a/frontend/app/components/ProjectsOverlay.tsx
+++ b/frontend/app/components/ProjectsOverlay.tsx
@@ -183,7 +183,10 @@ export default function ProjectsOverlay({ open, onClose }: ProjectsOverlayProps)
                   <span key={`${tag}-${index}`} className="project-detail__tag">{tag}</span>
                 ))}
               </div>
-              <p className="project-detail__description">{selectedProject.description}</p>
+              <div
+                className="project-detail__description"
+                dangerouslySetInnerHTML={{ __html: selectedProject.description }}
+              />
             </div>
             <div className="project-detail__video">
               {videoId && (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -451,6 +451,30 @@ body {
   margin: 0;
 }
 
+.project-detail__description p {
+  margin: 0 0 0.75em;
+}
+
+.project-detail__description p:last-child {
+  margin-bottom: 0;
+}
+
+.project-detail__description ul,
+.project-detail__description ol {
+  margin: 0 0 0.75em;
+  padding-left: 1.5em;
+}
+
+.project-detail__description a {
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.project-detail__description a:hover {
+  opacity: 0.7;
+}
+
 .project-detail__video {
   flex: 1;
   aspect-ratio: 16 / 9;


### PR DESCRIPTION
## Description

Closes #24

Ajoute un éditeur de texte riche (Wagtail RichTextField + Draftail) pour la description des projets et assure le rendu du texte riche côté frontend.

---

## Documentation

### Ce qui a été implémenté

**Backend :**
- `backend/projects/models.py` : champ `description` changé de `TextField` à `RichTextField` (Wagtail)
- `backend/projects/migrations/0003_rich_text_description.py` : migration pour le changement de type
- `backend/projects/views.py` : utilisation de `expand_db_html()` pour convertir le HTML interne Wagtail en HTML standard

**Frontend :**
- `frontend/app/components/ProjectsOverlay.tsx` : rendu HTML riche via `dangerouslySetInnerHTML`
- `frontend/app/globals.css` : styles pour le contenu riche (paragraphes, listes, liens)

### Choix techniques
- **RichTextField Wagtail natif** : pas de dépendance externe, éditeur Draftail intégré
- **`expand_db_html()`** : conversion des références internes Wagtail en URLs absolues
- **`dangerouslySetInnerHTML`** : sécurisé car le HTML provient de l'admin Wagtail (contenu de confiance)

### Comment tester
1. Appliquer la migration : `python manage.py migrate`
2. Admin Wagtail → Snippets → Projets → éditer un projet
3. Vérifier l'éditeur riche dans le champ Description
4. Côté public, vérifier le rendu formaté de la description