### PR TITLE
feat: accès aux contacts depuis l'admin Wagtail

### DIFF
--- a/backend/home/models.py
+++ b/backend/home/models.py
@@ -11,20 +11,58 @@ basculer le routing racine sur Wagtail, lance :
 dans config/urls.py.
 """
 
+from functools import cached_property
+
 from django.db import models
+from wagtail.admin.panels import FieldPanel
 from wagtail.models import Page
+from wagtail.permission_policies import ModelPermissionPolicy
+from wagtail.snippets.models import register_snippet
+from wagtail.snippets.views.snippets import SnippetViewSet
 
 
 class HomePage(Page):
     pass
 
 
+class ReadOnlyPermissionPolicy(ModelPermissionPolicy):
+    def user_has_permission(self, user, action):
+        if action in ("add", "change", "delete"):
+            return False
+        return super().user_has_permission(user, action)
+
+
+class ContactSubmissionViewSet(SnippetViewSet):
+    list_display = ["subject", "name", "email", "created_at"]
+    list_filter = {"created_at": ["gte", "lte"]}
+    search_fields = ["name", "email", "subject", "message"]
+    ordering = ["-created_at"]
+    icon = "mail"
+    add_to_admin_menu = True
+    menu_label = "Contacts"
+    menu_order = 300
+    inspect_view_enabled = True
+
+    @cached_property
+    def permission_policy(self):
+        return ReadOnlyPermissionPolicy(self.model)
+
+
+@register_snippet(ContactSubmissionViewSet)
 class ContactSubmission(models.Model):
     name = models.CharField("Nom", max_length=150)
     email = models.EmailField("Email")
     subject = models.CharField("Sujet", max_length=255)
     message = models.TextField("Message")
     created_at = models.DateTimeField("Date de soumission", auto_now_add=True)
+
+    panels = [
+        FieldPanel("name", read_only=True),
+        FieldPanel("email", read_only=True),
+        FieldPanel("subject", read_only=True),
+        FieldPanel("message", read_only=True),
+        FieldPanel("created_at", read_only=True),
+    ]
 
     class Meta:
         verbose_name = "Demande de contact"


### PR DESCRIPTION
## Description

Closes #28

Enregistre `ContactSubmission` comme snippet Wagtail avec un ViewSet personnalisé en lecture seule. Les contacts envoyés via le formulaire sont désormais consultables directement depuis l'admin Wagtail (`/admin/`), dans un menu dédié "Contacts".

---

## Documentation

### Ce qui a été implémenté
- **`backend/home/models.py`** : `ContactSubmission` enregistré comme snippet Wagtail via `ContactSubmissionViewSet`

### Choix techniques
- **`ReadOnlyPermissionPolicy`** : politique de permissions qui interdit add/change/delete
- **`inspect_view_enabled = True`** : vue détaillée en lecture seule
- **`add_to_admin_menu = True`** : menu "Contacts" dans la barre latérale Wagtail (icône mail)
- **Panneaux `read_only=True`** : tous les champs sont non-éditables
- **Liste enrichie** : affichage sujet/nom/email/date, filtrage par date, recherche textuelle

### Comment utiliser
1. Se connecter à `/admin/`
2. Cliquer sur "Contacts" dans le menu latéral
3. Voir la liste triée par date décroissante
4. Cliquer sur l'icône d'inspection pour voir le détail

### Points d'attention
- Aucune migration nécessaire (pas de changement de schéma)
- L'enregistrement Django admin existant reste en place