### PR TITLE
feat: close #44 - ajustement zone réseau

### DIFF
--- a/backend/network/views.py
+++ b/backend/network/views.py
@@ -15,7 +15,7 @@ def network_member_list(request):
             "member_type": member.member_type,
             "logo_url": (
                 request.build_absolute_uri(
-                    member.logo.get_rendition("fill-200x200").url
+                    member.logo.get_rendition("max-200x200").url
                 )
                 if member.logo
                 else None

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -289,9 +289,10 @@ Types d'accès :
 2. Scroller vers le bas depuis la vidéo de fond
 3. Vérifier que la section Réseau apparaît en scrollant par-dessus la vidéo
 4. Vérifier que la vidéo reste fixe en arrière-plan pendant le scroll
-5. Vérifier que les logos des membres du réseau s'affichent
+5. Vérifier que la section Réseau a un fond blanc
+6. Vérifier que les logos des membres du réseau s'affichent en entier (pas de troncature, même pour les logos non carrés)
 
-**Résultat attendu** : la section Réseau s'affiche au scroll, la vidéo reste fixe derrière, les logos des membres sont visibles.
+**Résultat attendu** : la section Réseau s'affiche au scroll sur fond blanc, la vidéo reste fixe derrière, les logos des membres sont visibles en entier sans troncature.
 
 ### NET-02 [PUBLIC] — Filtrage des membres du réseau par type
 1. Ouvrir `${BASE_URL}/`

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -540,7 +540,7 @@ body {
 .network-section {
   position: relative;
   z-index: 1;
-  background: #111;
+  background: #fff;
   padding: 4rem 2rem;
   min-height: 50vh;
 }
@@ -550,7 +550,7 @@ body {
   font-size: 2rem;
   font-weight: 700;
   margin: 0 0 2rem;
-  color: #fff;
+  color: #111;
 }
 
 .network-filters {
@@ -562,9 +562,9 @@ body {
 }
 
 .network-filters__btn {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(0, 0, 0, 0.06);
   border: none;
-  color: #fff;
+  color: #333;
   padding: 0.4rem 1rem;
   font-size: 0.85rem;
   text-transform: uppercase;
@@ -575,12 +575,12 @@ body {
 }
 
 .network-filters__btn:hover {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(0, 0, 0, 0.12);
 }
 
 .network-filters__btn--active {
-  background: #fff;
-  color: #000;
+  background: #111;
+  color: #fff;
 }
 
 .network-grid {
@@ -596,14 +596,14 @@ body {
   align-items: center;
   justify-content: center;
   aspect-ratio: 1;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(0, 0, 0, 0.03);
   border-radius: 0.5rem;
   padding: 1rem;
   transition: background 0.2s ease;
 }
 
 .network-card:hover {
-  background: rgba(255, 255, 255, 0.14);
+  background: rgba(0, 0, 0, 0.07);
 }
 
 .network-card__logo {
@@ -615,6 +615,7 @@ body {
 .network-card__name {
   font-size: 0.85rem;
   text-align: center;
+  color: #333;
   opacity: 0.7;
 }
 


### PR DESCRIPTION
## Description

Closes #44

La page réseau passe sur fond blanc et les logos s'affichent en entier (plus de troncature pour les logos non carrés).

---

## Modifications

**Backend** (`backend/network/views.py`) :
- Rendition Wagtail : `fill-200x200` → `max-200x200` (préserve le ratio d'aspect)

**Frontend** (`frontend/app/globals.css`) :
- Fond section réseau : `#111` → `#fff`
- Couleurs texte, boutons et cartes adaptées pour le thème clair

**Tests browser** (`docs/browser-test-checklist.md`) :
- Scénario NET-01 mis à jour : vérification du fond blanc et de l'affichage complet des logos

## Test plan
- [ ] Vérifier que la section réseau s'affiche sur fond blanc
- [ ] Vérifier que les logos non carrés s'affichent en entier (sans crop)
- [ ] Vérifier que les boutons de filtre sont lisibles sur fond clair
- [ ] Vérifier le rendu mobile de la section réseau

🤖 Generated with [Claude Code](https://claude.com/claude-code)