### PR TITLE
feat: refonte menu responsive avec hamburger mobile

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -58,15 +58,41 @@ Types d'accès :
 
 **Résultat attendu** : le header est présent et fonctionnel sur toutes les pages.
 
-### NAV-05 [PUBLIC] — Navigation responsive (titre en haut à gauche, menu en bas à droite)
+### NAV-05 [PUBLIC] — Menu hamburger sur mobile
 1. Ouvrir `${BASE_URL}/` en viewport mobile (375px de large)
 2. Vérifier que le titre « Cultur'all » est positionné en haut à gauche de l'écran
-3. Vérifier que les liens de navigation (« Nos Projets », « À propos », « Contact ») sont disposés verticalement en bas à droite de l'écran
-4. Vérifier que chaque lien de navigation est cliquable et fonctionne
-5. Naviguer vers `${BASE_URL}/a-propos` et vérifier que le header responsive est identique
-6. Naviguer vers `${BASE_URL}/contact` et vérifier que le header responsive est identique
+3. Vérifier que les liens de navigation ne sont **pas** visibles (masqués par défaut)
+4. Vérifier la présence d'un bouton hamburger (☰) en haut à droite
+5. Cliquer sur le bouton hamburger
+6. Vérifier que le menu s'ouvre en plein écran avec les 3 entrées : « Nos Projets », « À propos », « Contact »
+7. Cliquer sur « À propos »
+8. Vérifier que le menu se ferme et que la navigation vers `${BASE_URL}/a-propos` fonctionne
+9. Revenir sur `${BASE_URL}/` et rouvrir le menu hamburger
+10. Cliquer sur « Contact »
+11. Vérifier que le menu se ferme et que la navigation vers `${BASE_URL}/contact` fonctionne
 
-**Résultat attendu** : sur mobile, le titre est en haut à gauche, le menu apparaît à la verticale en bas à droite, tous les liens restent fonctionnels.
+**Résultat attendu** : sur mobile, le menu est masqué derrière un bouton hamburger, il s'ouvre en plein écran et se referme après navigation.
+
+### NAV-06 [PUBLIC] — Fermeture du menu hamburger par le bouton croix
+1. Ouvrir `${BASE_URL}/` en viewport mobile (375px de large)
+2. Cliquer sur le bouton hamburger
+3. Vérifier que le menu plein écran s'affiche
+4. Cliquer sur le bouton de fermeture (✕)
+5. Vérifier que le menu se referme
+6. Vérifier que la page d'accueil est toujours visible normalement
+
+**Résultat attendu** : le menu hamburger peut être fermé sans naviguer, retour à la page précédente.
+
+### NAV-07 [PUBLIC] — Ouverture de l'overlay Nos Projets depuis le menu hamburger mobile
+1. Ouvrir `${BASE_URL}/` en viewport mobile (375px de large)
+2. Cliquer sur le bouton hamburger
+3. Cliquer sur « Nos Projets »
+4. Vérifier que le menu hamburger se ferme
+5. Vérifier que l'overlay des projets s'ouvre par-dessus la page d'accueil (comme avant)
+6. Fermer l'overlay des projets
+7. Vérifier que la page d'accueil est visible normalement
+
+**Résultat attendu** : depuis le menu hamburger, « Nos Projets » ferme le menu et ouvre l'overlay projets normalement.
 
 ## 2. Formulaire de contact
 

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -15,11 +15,25 @@ export default function Header() {
   const router = useRouter();
 
   useEffect(() => {
+    setMenuOpen(false);
     fetch(`${API_URL}/api/auth/check/`, { credentials: 'include' })
       .then((res) => res.json())
       .then((data) => setAuthenticated(data.authenticated))
       .catch(() => setAuthenticated(false));
   }, [pathname]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    document.body.style.overflow = 'hidden';
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMenuOpen(false);
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [menuOpen]);
 
   async function handleLogout() {
     await fetch(`${API_URL}/api/auth/logout/`, {
@@ -44,8 +58,9 @@ export default function Header() {
           className="header-burger"
           onClick={() => setMenuOpen(!menuOpen)}
           aria-label={menuOpen ? 'Fermer le menu' : 'Ouvrir le menu'}
+          aria-expanded={menuOpen}
         >
-          {menuOpen ? '✕' : '☰'}
+          <span aria-hidden="true">{menuOpen ? '✕' : '☰'}</span>
         </button>
         <nav className={`header-nav${menuOpen ? ' header-nav--open' : ''}`}>
           <button
@@ -57,8 +72,8 @@ export default function Header() {
           >
             Nos Projets
           </button>
-          <Link href="/a-propos" onClick={() => setMenuOpen(false)}>À propos</Link>
-          <Link href="/contact" onClick={() => setMenuOpen(false)}>Contact</Link>
+          <Link href="/a-propos">À propos</Link>
+          <Link href="/contact">Contact</Link>
           {authenticated && (
             <button className="header-nav__link" onClick={handleLogout}>
               Déconnexion

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -9,6 +9,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 export default function Header() {
   const [projectsOpen, setProjectsOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
   const pathname = usePathname();
   const router = useRouter();
@@ -39,15 +40,25 @@ export default function Header() {
         <Link href="/" className="header-title">
           Cultur&apos;all
         </Link>
-        <nav className="header-nav">
+        <button
+          className="header-burger"
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label={menuOpen ? 'Fermer le menu' : 'Ouvrir le menu'}
+        >
+          {menuOpen ? '✕' : '☰'}
+        </button>
+        <nav className={`header-nav${menuOpen ? ' header-nav--open' : ''}`}>
           <button
             className="header-nav__link"
-            onClick={() => setProjectsOpen(true)}
+            onClick={() => {
+              setMenuOpen(false);
+              setProjectsOpen(true);
+            }}
           >
             Nos Projets
           </button>
-          <Link href="/a-propos">À propos</Link>
-          <Link href="/contact">Contact</Link>
+          <Link href="/a-propos" onClick={() => setMenuOpen(false)}>À propos</Link>
+          <Link href="/contact" onClick={() => setMenuOpen(false)}>Contact</Link>
           {authenticated && (
             <button className="header-nav__link" onClick={handleLogout}>
               Déconnexion

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -56,6 +56,18 @@ body {
   opacity: 0.8;
 }
 
+/* Hamburger button — hidden on desktop, visible on mobile */
+.header-burger {
+  display: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  z-index: 12;
+}
+
 /* Landing page */
 .landing {
   position: sticky;
@@ -626,24 +638,45 @@ body {
     top: 0;
     left: 0;
     right: 0;
-    bottom: 0;
-    flex-direction: column;
+    display: flex;
+    flex-direction: row;
     justify-content: space-between;
-    align-items: stretch;
+    align-items: center;
     padding: 1rem 1.5rem;
-    pointer-events: none;
+    z-index: 10;
   }
 
   .header-title {
-    align-self: flex-start;
+    pointer-events: auto;
+  }
+
+  .header-burger {
+    display: block;
     pointer-events: auto;
   }
 
   .header-nav {
+    position: fixed;
+    inset: 0;
     flex-direction: column;
-    align-items: flex-end;
-    gap: 0.75rem;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    background: rgba(0, 0, 0, 0.95);
+    z-index: 11;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+  }
+
+  .header-nav--open {
+    opacity: 1;
     pointer-events: auto;
+  }
+
+  .header-nav a,
+  .header-nav .header-nav__link {
+    font-size: 1.5rem;
   }
 
   .page {

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -634,20 +634,7 @@ body {
 /* Responsive */
 @media (max-width: 768px) {
   .header {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
     padding: 1rem 1.5rem;
-    z-index: 10;
-  }
-
-  .header-title {
-    pointer-events: auto;
   }
 
   .header-burger {


### PR DESCRIPTION
## Description

Closes #48

Refonte du menu mobile : le menu de navigation est masqué sur mobile derrière un bouton hamburger (☰). Au clic, un menu plein écran s'affiche avec les 3 entrées (Nos Projets, À propos, Contact). Le clic sur un lien ferme le menu et navigue. Le clic sur "Nos Projets" ferme le menu et ouvre l'overlay projets comme avant.

---

## Documentation

### Fichiers modifiés
- **`frontend/app/components/Header.tsx`** : état `menuOpen`, bouton hamburger, fermeture auto du menu
- **`frontend/app/globals.css`** : styles hamburger, menu overlay plein écran mobile

### Choix techniques
- Overlay CSS plein écran (`position: fixed; inset: 0`) avec transition d'opacité
- Bouton hamburger ☰/✕ via état React, sans dépendance externe
- z-index : header (10) < menu (11) < hamburger (12) < overlay projets (100)
- Liens en `1.5rem` pour accessibilité tactile mobile