### PR TITLE
[ci-autofix] Fix: remove invalid MissingModel import in test_contact.py

### DIFF
--- a/backend/home/tests/test_contact.py
+++ b/backend/home/tests/test_contact.py
@@ -3,7 +3,7 @@ import json
 import pytest
 from django.test import Client
 
-from home.models import ContactSubmission, MissingModel
+from home.models import ContactSubmission
 
 pytestmark = pytest.mark.django_db
 


### PR DESCRIPTION
## Fix automatique CI

Closes #56

### Probleme
Le fichier `backend/home/tests/test_contact.py` importait `MissingModel` depuis `home.models`, mais ce modele n'existe pas, causant une `ImportError` lors de la collection des tests par pytest.

### Fix applique
Suppression de l'import invalide `MissingModel` de la ligne 6. Seul `ContactSubmission` est conserve, qui est le seul modele utilise dans les tests.

### Verification
- [ ] Tests backend passes en CI
- [ ] Review manuelle recommandee

---
_PR creee automatiquement par ci-autofix_