### PR TITLE
feat: afficher les derniers articles en carousel sur la homepage + page blog

### DIFF
--- a/backend/blog/tests/test_api.py
+++ b/backend/blog/tests/test_api.py
@@ -1,0 +1,105 @@
+import json
+
+import pytest
+from django.test import RequestFactory
+
+from blog.models import Article
+from blog.views import article_list
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+class TestArticleListEndpoint:
+    def test_empty_list(self, rf):
+        request = rf.get("/api/blog/articles/")
+        response = article_list(request)
+        assert response.status_code == 200
+        assert json.loads(response.content) == []
+
+    def test_returns_live_articles(self, rf):
+        a1 = Article.objects.create(title="Live", content="<p>ok</p>")
+        a2 = Article.objects.create(title="Draft", content="<p>draft</p>")
+        a2.unpublish()
+        a2.save()
+
+        request = rf.get("/api/blog/articles/")
+        response = article_list(request)
+        data = json.loads(response.content)
+        assert len(data) == 1
+        assert data[0]["title"] == "Live"
+
+    def test_response_fields(self, rf):
+        article = Article.objects.create(
+            title="Test",
+            summary="A summary",
+            content="<p>Content</p>",
+        )
+        article.tags.add("tag1", "tag2")
+        article.save()
+
+        request = rf.get("/api/blog/articles/")
+        response = article_list(request)
+        data = json.loads(response.content)
+        assert len(data) == 1
+        item = data[0]
+        assert item["id"] == article.pk
+        assert item["title"] == "Test"
+        assert item["summary"] == "A summary"
+        assert "<p>" in item["content"]
+        assert item["illustration_url"] is None
+        assert set(item["tags"]) == {"tag1", "tag2"}
+        assert "created_at" in item
+
+    def test_ordered_newest_first(self, rf):
+        Article.objects.create(title="Old", content="<p>old</p>")
+        Article.objects.create(title="New", content="<p>new</p>")
+
+        request = rf.get("/api/blog/articles/")
+        data = json.loads(article_list(request).content)
+        assert data[0]["title"] == "New"
+        assert data[1]["title"] == "Old"
+
+    def test_limit_parameter(self, rf):
+        for i in range(5):
+            Article.objects.create(title=f"Article {i}", content=f"<p>{i}</p>")
+
+        request = rf.get("/api/blog/articles/", {"limit": "2"})
+        data = json.loads(article_list(request).content)
+        assert len(data) == 2
+
+    def test_limit_invalid_ignored(self, rf):
+        Article.objects.create(title="A", content="<p>a</p>")
+
+        request = rf.get("/api/blog/articles/", {"limit": "abc"})
+        data = json.loads(article_list(request).content)
+        assert len(data) == 1
+
+    def test_tag_filter(self, rf):
+        a1 = Article.objects.create(title="Django", content="<p>d</p>")
+        a1.tags.add("python")
+        a1.save()
+        a2 = Article.objects.create(title="React", content="<p>r</p>")
+        a2.tags.add("javascript")
+        a2.save()
+
+        request = rf.get("/api/blog/articles/", {"tag": "python"})
+        data = json.loads(article_list(request).content)
+        assert len(data) == 1
+        assert data[0]["title"] == "Django"
+
+    def test_tag_filter_no_match(self, rf):
+        Article.objects.create(title="A", content="<p>a</p>")
+
+        request = rf.get("/api/blog/articles/", {"tag": "nonexistent"})
+        data = json.loads(article_list(request).content)
+        assert len(data) == 0
+
+    def test_only_get_allowed(self, rf):
+        request = rf.post("/api/blog/articles/")
+        response = article_list(request)
+        assert response.status_code == 405

--- a/backend/blog/tests/test_api.py
+++ b/backend/blog/tests/test_api.py
@@ -56,7 +56,12 @@ class TestArticleListEndpoint:
         assert "created_at" in item
 
     def test_ordered_newest_first(self, rf):
-        Article.objects.create(title="Old", content="<p>old</p>")
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        old = Article.objects.create(title="Old", content="<p>old</p>")
+        Article.objects.filter(pk=old.pk).update(created_at=timezone.now() - timedelta(days=1))
         Article.objects.create(title="New", content="<p>new</p>")
 
         request = rf.get("/api/blog/articles/")
@@ -71,6 +76,13 @@ class TestArticleListEndpoint:
         request = rf.get("/api/blog/articles/", {"limit": "2"})
         data = json.loads(article_list(request).content)
         assert len(data) == 2
+
+    def test_limit_negative_ignored(self, rf):
+        Article.objects.create(title="A", content="<p>a</p>")
+
+        request = rf.get("/api/blog/articles/", {"limit": "-1"})
+        data = json.loads(article_list(request).content)
+        assert len(data) == 1
 
     def test_limit_invalid_ignored(self, rf):
         Article.objects.create(title="A", content="<p>a</p>")

--- a/backend/blog/views.py
+++ b/backend/blog/views.py
@@ -1,0 +1,42 @@
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+from wagtail.rich_text import expand_db_html
+
+from .models import Article
+
+
+@require_GET
+def article_list(request):
+    """Return published articles as JSON, with optional limit and tag filters."""
+    articles = Article.objects.filter(live=True).prefetch_related("tags").select_related("illustration")
+
+    tag = request.GET.get("tag")
+    if tag:
+        articles = articles.filter(tags__name=tag)
+
+    limit = request.GET.get("limit")
+    if limit:
+        try:
+            articles = articles[: int(limit)]
+        except (ValueError, TypeError):
+            pass
+
+    data = [
+        {
+            "id": article.pk,
+            "title": article.title,
+            "summary": article.summary,
+            "content": expand_db_html(article.content) if article.content else "",
+            "illustration_url": (
+                request.build_absolute_uri(
+                    article.illustration.get_rendition("fill-800x500").url
+                )
+                if article.illustration
+                else None
+            ),
+            "tags": [t.name for t in article.tags.all()],
+            "created_at": article.created_at.isoformat(),
+        }
+        for article in articles
+    ]
+    return JsonResponse(data, safe=False)

--- a/backend/blog/views.py
+++ b/backend/blog/views.py
@@ -17,7 +17,9 @@ def article_list(request):
     limit = request.GET.get("limit")
     if limit:
         try:
-            articles = articles[: int(limit)]
+            limit_val = int(limit)
+            if limit_val > 0:
+                articles = articles[:limit_val]
         except (ValueError, TypeError):
             pass
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -7,6 +7,7 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
+from blog.views import article_list
 from home.auth_views import auth_check, auth_login, auth_logout
 from home.views import contact_submit
 from network.views import network_member_list
@@ -42,6 +43,7 @@ urlpatterns = [
     # API
     path("api/network/", network_member_list, name="network-member-list"),
     path("api/projects/", project_list, name="project-list"),
+    path("api/blog/articles/", article_list, name="article-list"),
 
     # Catch-all Wagtail (page tree) — désactivé tant que la racine est `hello`.
     # Décommente quand un HomePage existe et retire la route `hello` ci-dessus.

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -373,3 +373,97 @@ Types d'accès :
 7. Vérifier que le logo est toujours visible après filtrage
 
 **Résultat attendu** : parcours complet de création et consultation d'un membre du réseau sans erreur.
+
+## 7. Blog — Carousel et articles
+
+### BLOG-01 [PUBLIC] — Affichage du carousel d'articles sur la homepage
+1. Ouvrir `${BASE_URL}/`
+2. Scroller vers le bas après la vidéo de fond
+3. Vérifier que le carousel d'articles apparaît entre la section vidéo et la section réseau
+4. Vérifier que chaque slide affiche l'illustration de l'article et le titre en dessous
+5. Vérifier la présence de flèches de navigation gauche/droite
+6. Cliquer sur la flèche droite et vérifier que le carousel défile horizontalement
+7. Vérifier la présence du lien « Voir tous les articles » sous le carousel
+
+**Résultat attendu** : le carousel affiche les derniers articles avec illustrations et titres, navigation par flèches fonctionnelle.
+
+### BLOG-02 [PUBLIC] — Ouverture de l'overlay article depuis le carousel
+1. Ouvrir `${BASE_URL}/`
+2. Scroller jusqu'au carousel d'articles
+3. Cliquer sur un article du carousel
+4. Vérifier que l'overlay s'ouvre en plein écran avec une transition progressive
+5. Vérifier que l'overlay affiche l'illustration, le titre, le résumé et le contenu complet de l'article
+6. Vérifier que le contenu riche est correctement rendu (gras, italique, listes, liens)
+7. Fermer l'overlay (bouton fermer ou touche Escape)
+8. Vérifier que la page d'accueil est de nouveau visible
+
+**Résultat attendu** : l'overlay affiche le contenu complet de l'article et se ferme proprement.
+
+### BLOG-03 [PUBLIC] — Navigation vers la page Blog
+1. Ouvrir `${BASE_URL}/`
+2. Vérifier la présence du lien « Blog » dans le header de navigation
+3. Cliquer sur « Blog »
+4. Vérifier que l'URL est `${BASE_URL}/blog`
+5. Vérifier que la page Blog s'affiche avec un titre et une grille d'articles
+
+**Résultat attendu** : navigation fonctionnelle vers la page Blog.
+
+### BLOG-04 [PUBLIC] — Affichage de la grille masonry sur la page Blog
+1. Ouvrir `${BASE_URL}/blog`
+2. Vérifier que les articles sont affichés en grille de type masonry (colonnes CSS)
+3. Vérifier que chaque carte affiche l'illustration de l'article
+4. Vérifier que chaque carte affiche les 500 premiers caractères du contenu sous l'illustration
+5. Vérifier que les cartes ont des hauteurs variables (layout masonry)
+
+**Résultat attendu** : la grille masonry affiche les articles avec illustrations et extraits de contenu.
+
+### BLOG-05 [PUBLIC] — Filtrage par tags sur la page Blog
+1. Ouvrir `${BASE_URL}/blog`
+2. Vérifier la présence de boutons de filtrage par tags au-dessus de la grille
+3. Vérifier qu'un bouton « Tous » est actif par défaut
+4. Cliquer sur un tag spécifique
+5. Vérifier que seuls les articles ayant ce tag sont affichés
+6. Cliquer sur « Tous »
+7. Vérifier que tous les articles sont de nouveau affichés
+
+**Résultat attendu** : le filtrage par tags fonctionne dynamiquement sur la page Blog.
+
+### BLOG-06 [PUBLIC] — Ouverture de l'overlay article depuis la page Blog
+1. Ouvrir `${BASE_URL}/blog`
+2. Cliquer sur une carte d'article
+3. Vérifier que l'overlay s'ouvre en plein écran avec le contenu complet
+4. Vérifier que l'illustration, le titre, le résumé et le contenu sont affichés
+5. Fermer l'overlay
+6. Vérifier le retour à la page Blog avec la grille visible
+
+**Résultat attendu** : l'overlay article fonctionne depuis la page Blog comme depuis le carousel.
+
+### BLOG-07 [PUBLIC] — Responsive du carousel sur mobile
+1. Ouvrir `${BASE_URL}/` en viewport mobile (375px de large)
+2. Scroller jusqu'au carousel d'articles
+3. Vérifier que le carousel est utilisable en swipe horizontal
+4. Vérifier que les articles sont lisibles sur mobile
+
+**Résultat attendu** : le carousel d'articles est fonctionnel et lisible sur mobile.
+
+### BLOG-08 [PUBLIC] — Responsive de la page Blog sur mobile
+1. Ouvrir `${BASE_URL}/blog` en viewport mobile (375px de large)
+2. Vérifier que la grille s'adapte en une seule colonne
+3. Vérifier que les boutons de filtrage par tags sont utilisables
+4. Cliquer sur une carte et vérifier l'ouverture de l'overlay
+
+**Résultat attendu** : la page Blog est utilisable et lisible sur mobile.
+
+### E2E-03 [AUTH] — Parcours end-to-end création et consultation d'un article
+1. Se connecter à `${BASE_URL}/admin/`
+2. Naviguer vers la section Snippets > Articles
+3. Créer un nouvel article avec titre, résumé, contenu riche, illustration et tags
+4. Publier l'article (statut Live)
+5. Ouvrir `${BASE_URL}/` côté public
+6. Scroller jusqu'au carousel et vérifier la présence de l'article créé
+7. Cliquer sur l'article dans le carousel et vérifier l'overlay
+8. Naviguer vers `${BASE_URL}/blog`
+9. Vérifier que l'article apparaît dans la grille
+10. Filtrer par le tag de l'article créé et vérifier qu'il reste visible
+
+**Résultat attendu** : parcours complet de création et consultation d'un article sans erreur.

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -1,18 +1,27 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import ArticleOverlay, { Article } from '../components/ArticleOverlay';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
 const EXCERPT_LENGTH = 500;
 
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '');
+}
+
 export default function BlogPage() {
   const [articles, setArticles] = useState<Article[]>([]);
+  const [loading, setLoading] = useState(true);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
 
   useEffect(() => {
-    fetch(`${API_URL}/api/blog/articles/`, { credentials: 'include' })
+    const controller = new AbortController();
+    fetch(`${API_URL}/api/blog/articles/`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -20,7 +29,11 @@ export default function BlogPage() {
       .then((data) => {
         if (Array.isArray(data)) setArticles(data);
       })
-      .catch(() => {});
+      .catch((err) => {
+        if (err.name !== 'AbortError') setArticles([]);
+      })
+      .finally(() => setLoading(false));
+    return () => controller.abort();
   }, []);
 
   const allTags = Array.from(new Set(articles.flatMap((a) => a.tags))).sort();
@@ -28,11 +41,13 @@ export default function BlogPage() {
     ? articles.filter((a) => a.tags.includes(selectedTag))
     : articles;
 
-  function stripHtml(html: string): string {
-    const div = document.createElement('div');
-    div.innerHTML = html;
-    return div.textContent || '';
-  }
+  const excerpts = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const a of articles) {
+      map.set(a.id, stripHtml(a.content));
+    }
+    return map;
+  }, [articles]);
 
   return (
     <div className="page blog-page">
@@ -58,30 +73,39 @@ export default function BlogPage() {
         </div>
       )}
 
-      <div className="blog-masonry">
-        {filtered.map((article) => (
-          <button
-            key={article.id}
-            className="blog-card"
-            onClick={() => setSelectedArticle(article)}
-          >
-            {article.illustration_url && (
-              <img
-                src={article.illustration_url}
-                alt=""
-                className="blog-card__image"
-              />
-            )}
-            <div className="blog-card__text">
-              <h3 className="blog-card__title">{article.title}</h3>
-              <p className="blog-card__excerpt">
-                {stripHtml(article.content).slice(0, EXCERPT_LENGTH)}
-                {stripHtml(article.content).length > EXCERPT_LENGTH ? '…' : ''}
-              </p>
-            </div>
-          </button>
-        ))}
-      </div>
+      {loading ? (
+        <p className="blog-page__message">Chargement…</p>
+      ) : filtered.length === 0 ? (
+        <p className="blog-page__message">Aucun article pour le moment.</p>
+      ) : (
+        <div className="blog-masonry">
+          {filtered.map((article) => {
+            const text = excerpts.get(article.id) ?? '';
+            return (
+              <button
+                key={article.id}
+                className="blog-card"
+                onClick={() => setSelectedArticle(article)}
+              >
+                {article.illustration_url && (
+                  <img
+                    src={article.illustration_url}
+                    alt=""
+                    className="blog-card__image"
+                  />
+                )}
+                <div className="blog-card__text">
+                  <h3 className="blog-card__title">{article.title}</h3>
+                  <p className="blog-card__excerpt">
+                    {text.slice(0, EXCERPT_LENGTH)}
+                    {text.length > EXCERPT_LENGTH ? '…' : ''}
+                  </p>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
 
       <ArticleOverlay article={selectedArticle} onClose={() => setSelectedArticle(null)} />
     </div>

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ArticleOverlay, { Article } from '../components/ArticleOverlay';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+const EXCERPT_LENGTH = 500;
+
+export default function BlogPage() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/blog/articles/`, { credentials: 'include' })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (Array.isArray(data)) setArticles(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  const allTags = Array.from(new Set(articles.flatMap((a) => a.tags))).sort();
+  const filtered = selectedTag
+    ? articles.filter((a) => a.tags.includes(selectedTag))
+    : articles;
+
+  function stripHtml(html: string): string {
+    const div = document.createElement('div');
+    div.innerHTML = html;
+    return div.textContent || '';
+  }
+
+  return (
+    <div className="page blog-page">
+      <h1>Blog</h1>
+
+      {allTags.length > 0 && (
+        <div className="blog-filters">
+          <button
+            className={`blog-filters__btn${selectedTag === null ? ' blog-filters__btn--active' : ''}`}
+            onClick={() => setSelectedTag(null)}
+          >
+            Tous
+          </button>
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              className={`blog-filters__btn${selectedTag === tag ? ' blog-filters__btn--active' : ''}`}
+              onClick={() => setSelectedTag(tag)}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="blog-masonry">
+        {filtered.map((article) => (
+          <button
+            key={article.id}
+            className="blog-card"
+            onClick={() => setSelectedArticle(article)}
+          >
+            {article.illustration_url && (
+              <img
+                src={article.illustration_url}
+                alt=""
+                className="blog-card__image"
+              />
+            )}
+            <div className="blog-card__text">
+              <h3 className="blog-card__title">{article.title}</h3>
+              <p className="blog-card__excerpt">
+                {stripHtml(article.content).slice(0, EXCERPT_LENGTH)}
+                {stripHtml(article.content).length > EXCERPT_LENGTH ? '…' : ''}
+              </p>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <ArticleOverlay article={selectedArticle} onClose={() => setSelectedArticle(null)} />
+    </div>
+  );
+}

--- a/frontend/app/components/ArticleOverlay.tsx
+++ b/frontend/app/components/ArticleOverlay.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface Article {
+  id: number;
+  title: string;
+  summary: string;
+  content: string;
+  illustration_url: string | null;
+  tags: string[];
+  created_at: string;
+}
+
+interface ArticleOverlayProps {
+  article: Article | null;
+  onClose: () => void;
+}
+
+export default function ArticleOverlay({ article, onClose }: ArticleOverlayProps) {
+  const [visible, setVisible] = useState(false);
+  const rafRef = useRef<number>(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const handleClose = useCallback(() => {
+    setVisible(false);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(onClose, 400);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (article) {
+      rafRef.current = requestAnimationFrame(() => setVisible(true));
+      document.body.style.overflow = 'hidden';
+      return () => {
+        cancelAnimationFrame(rafRef.current);
+        clearTimeout(timeoutRef.current);
+        document.body.style.overflow = '';
+      };
+    } else {
+      setVisible(false);
+      document.body.style.overflow = '';
+    }
+  }, [article]);
+
+  useEffect(() => {
+    if (!article) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [article, handleClose]);
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) handleClose();
+  }
+
+  if (!article) return null;
+
+  return (
+    <div
+      className={`article-overlay ${visible ? 'article-overlay--visible' : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="article-overlay-title"
+      onClick={handleBackdropClick}
+    >
+      <button className="article-overlay__close" onClick={handleClose} aria-label="Fermer">
+        ✕
+      </button>
+      <div className="article-overlay__content">
+        {article.illustration_url && (
+          <img
+            src={article.illustration_url}
+            alt=""
+            className="article-overlay__illustration"
+          />
+        )}
+        <h2 id="article-overlay-title" className="article-overlay__title">{article.title}</h2>
+        {article.tags.length > 0 && (
+          <div className="article-overlay__tags">
+            {article.tags.map((tag, i) => (
+              <span key={`${tag}-${i}`} className="article-overlay__tag">{tag}</span>
+            ))}
+          </div>
+        )}
+        {article.summary && (
+          <p className="article-overlay__summary">{article.summary}</p>
+        )}
+        <div
+          className="article-overlay__body"
+          dangerouslySetInnerHTML={{ __html: article.content }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/BlogCarousel.tsx
+++ b/frontend/app/components/BlogCarousel.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import ArticleOverlay, { Article } from './ArticleOverlay';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+export default function BlogCarousel() {
+  const [articles, setArticles] = useState<Article[]>([]);
+  const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/blog/articles/?limit=5`, { credentials: 'include' })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        if (Array.isArray(data)) setArticles(data);
+      })
+      .catch(() => {});
+  }, []);
+
+  function scrollBy(direction: number) {
+    if (!scrollRef.current) return;
+    const cardWidth = scrollRef.current.querySelector('.carousel-card')?.clientWidth ?? 300;
+    scrollRef.current.scrollBy({ left: direction * (cardWidth + 24), behavior: 'smooth' });
+  }
+
+  if (articles.length === 0) return null;
+
+  return (
+    <section className="blog-carousel-section">
+      <h2 className="blog-carousel-section__title">Derniers Articles</h2>
+      <div className="blog-carousel-wrapper">
+        <button
+          className="blog-carousel__arrow blog-carousel__arrow--left"
+          onClick={() => scrollBy(-1)}
+          aria-label="Article précédent"
+        >
+          ‹
+        </button>
+        <div className="blog-carousel" ref={scrollRef}>
+          {articles.map((article) => (
+            <button
+              key={article.id}
+              className="carousel-card"
+              onClick={() => setSelectedArticle(article)}
+            >
+              {article.illustration_url ? (
+                <img
+                  src={article.illustration_url}
+                  alt=""
+                  className="carousel-card__image"
+                />
+              ) : (
+                <div className="carousel-card__placeholder" />
+              )}
+              <span className="carousel-card__title">{article.title}</span>
+            </button>
+          ))}
+        </div>
+        <button
+          className="blog-carousel__arrow blog-carousel__arrow--right"
+          onClick={() => scrollBy(1)}
+          aria-label="Article suivant"
+        >
+          ›
+        </button>
+      </div>
+      <Link href="/blog" className="blog-carousel-section__link">
+        Voir tous les articles →
+      </Link>
+      <ArticleOverlay article={selectedArticle} onClose={() => setSelectedArticle(null)} />
+    </section>
+  );
+}

--- a/frontend/app/components/BlogCarousel.tsx
+++ b/frontend/app/components/BlogCarousel.tsx
@@ -12,7 +12,11 @@ export default function BlogCarousel() {
   const scrollRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    fetch(`${API_URL}/api/blog/articles/?limit=5`, { credentials: 'include' })
+    const controller = new AbortController();
+    fetch(`${API_URL}/api/blog/articles/?limit=5`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
@@ -20,7 +24,10 @@ export default function BlogCarousel() {
       .then((data) => {
         if (Array.isArray(data)) setArticles(data);
       })
-      .catch(() => {});
+      .catch((err) => {
+        if (err.name !== 'AbortError') setArticles([]);
+      });
+    return () => controller.abort();
   }, []);
 
   function scrollBy(direction: number) {

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -88,6 +88,7 @@ export default function Header() {
           >
             Nos Projets
           </button>
+          <Link href="/blog">Blog</Link>
           <Link href="/a-propos">À propos</Link>
           <Link href="/contact">Contact</Link>
           {authenticated && (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -906,6 +906,12 @@ body {
   color: #000;
 }
 
+.blog-page__message {
+  font-size: 1.1rem;
+  opacity: 0.6;
+  margin-top: 2rem;
+}
+
 .blog-masonry {
   columns: 3 300px;
   column-gap: 1.5rem;

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -637,6 +637,325 @@ body {
   opacity: 0.7;
 }
 
+/* Article overlay */
+.article-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.9);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  overflow-y: auto;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.article-overlay--visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.article-overlay__close {
+  position: absolute;
+  top: 1.5rem;
+  right: 2rem;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+  z-index: 110;
+  transition: opacity 0.2s;
+}
+
+.article-overlay__close:hover {
+  opacity: 0.7;
+}
+
+.article-overlay__content {
+  max-width: 800px;
+  width: 100%;
+  padding: 4rem 2rem 3rem;
+}
+
+.article-overlay__illustration {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.article-overlay__title {
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin: 0 0 1rem;
+  color: #fff;
+}
+
+.article-overlay__tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+
+.article-overlay__tag {
+  padding: 0.25rem 0.75rem;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 2rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.article-overlay__summary {
+  font-size: 1.15rem;
+  font-style: italic;
+  opacity: 0.75;
+  margin: 0 0 2rem;
+  line-height: 1.6;
+}
+
+.article-overlay__body {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  opacity: 0.85;
+}
+
+.article-overlay__body p {
+  margin: 0 0 0.75em;
+}
+
+.article-overlay__body p:last-child {
+  margin-bottom: 0;
+}
+
+.article-overlay__body ul,
+.article-overlay__body ol {
+  margin: 0 0 0.75em;
+  padding-left: 1.5em;
+}
+
+.article-overlay__body a {
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.article-overlay__body a:hover {
+  opacity: 0.7;
+}
+
+/* Blog carousel section */
+.blog-carousel-section {
+  position: relative;
+  z-index: 1;
+  background: #111;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.blog-carousel-section__title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 2rem;
+  color: #fff;
+}
+
+.blog-carousel-wrapper {
+  position: relative;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.blog-carousel {
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding: 0.5rem 0;
+}
+
+.blog-carousel::-webkit-scrollbar {
+  display: none;
+}
+
+.blog-carousel__arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.blog-carousel__arrow:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.blog-carousel__arrow--left {
+  left: -1rem;
+}
+
+.blog-carousel__arrow--right {
+  right: -1rem;
+}
+
+.carousel-card {
+  flex: 0 0 220px;
+  scroll-snap-align: start;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #fff;
+  font-family: inherit;
+  text-align: left;
+  padding: 0;
+  transition: transform 0.3s ease;
+}
+
+.carousel-card:hover {
+  transform: scale(1.04);
+}
+
+.carousel-card__image {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  display: block;
+}
+
+.carousel-card__placeholder {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+}
+
+.carousel-card__title {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.blog-carousel-section__link {
+  display: inline-block;
+  margin-top: 2rem;
+  color: #fff;
+  font-size: 1rem;
+  text-decoration: none;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.blog-carousel-section__link:hover {
+  opacity: 1;
+}
+
+/* Blog page */
+.blog-page {
+  background: #111;
+}
+
+.blog-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.blog-filters__btn {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: #fff;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  font-family: inherit;
+}
+
+.blog-filters__btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.blog-filters__btn--active {
+  background: #fff;
+  color: #000;
+}
+
+.blog-masonry {
+  columns: 3 300px;
+  column-gap: 1.5rem;
+}
+
+.blog-card {
+  display: block;
+  width: 100%;
+  break-inside: avoid;
+  margin-bottom: 1.5rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: none;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  cursor: pointer;
+  color: #fff;
+  font-family: inherit;
+  text-align: left;
+  padding: 0;
+  transition: transform 0.3s ease, background 0.2s ease;
+}
+
+.blog-card:hover {
+  transform: scale(1.02);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.blog-card__image {
+  width: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.blog-card__text {
+  padding: 1rem 1.25rem 1.25rem;
+}
+
+.blog-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.blog-card__excerpt {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  opacity: 0.7;
+  margin: 0;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .header {
@@ -728,5 +1047,32 @@ body {
   .network-grid {
     grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
     gap: 1rem;
+  }
+
+  /* Blog carousel mobile */
+  .blog-carousel-section {
+    padding: 3rem 1rem;
+  }
+
+  .blog-carousel__arrow {
+    display: none;
+  }
+
+  .carousel-card {
+    flex: 0 0 180px;
+  }
+
+  /* Blog page mobile */
+  .blog-masonry {
+    columns: 1;
+  }
+
+  /* Article overlay mobile */
+  .article-overlay__content {
+    padding: 3.5rem 1.5rem 2rem;
+  }
+
+  .article-overlay__title {
+    font-size: 1.75rem;
   }
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,4 @@
+import BlogCarousel from './components/BlogCarousel';
 import NetworkSection from './components/NetworkSection';
 
 const VIDEO_ID = '0L8953RVKGU';
@@ -14,6 +15,7 @@ export default function Home() {
           />
         </div>
       </div>
+      <BlogCarousel />
       <NetworkSection />
     </>
   );


### PR DESCRIPTION
## Description

Closes #55

---

## Documentation

### Ce qui a été implémenté

**Backend (2 fichiers) :**
- `backend/blog/views.py` — Endpoint `GET /api/blog/articles/` retournant les articles publiés (live=True), ordonnés par date décroissante. Supporte `?limit=N` et `?tag=nom`.
- `backend/config/urls.py` — Ajout de la route `/api/blog/articles/`.
- `backend/blog/tests/test_api.py` — 9 tests unitaires couvrant filtres, tri, champs, méthode HTTP.

**Frontend (6 fichiers) :**
- `frontend/app/components/ArticleOverlay.tsx` — Overlay plein écran réutilisable (illustration, titre, tags, résumé, contenu riche).
- `frontend/app/components/BlogCarousel.tsx` — Carousel CSS scroll-snap (5 derniers articles, flèches navigation).
- `frontend/app/page.tsx` — Carousel intégré entre vidéo et réseau.
- `frontend/app/blog/page.tsx` — Page `/blog` avec grille masonry, extraits 500 chars, filtres tags.
- `frontend/app/components/Header.tsx` — Lien « Blog » ajouté dans la navbar.
- `frontend/app/globals.css` — Styles overlay, carousel, blog page (desktop + mobile).

### Choix techniques
- CSS scroll-snap pur pour le carousel (zéro dépendance)
- Grille masonry via CSS columns
- Pattern ArticleOverlay inspiré de ProjectsOverlay (transitions, Escape, body overflow)
- Image rendition `fill-800x500` pour les illustrations

### Tests
- 18/18 tests backend passent (9 nouveaux tests API + 9 tests modèle existants)