### PR TITLE
feat: fix mentions légales 404 page

### DIFF
--- a/frontend/app/mentions-legales/page.tsx
+++ b/frontend/app/mentions-legales/page.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Mentions légales',
+};
+
+export default function MentionsLegales() {
+  return (
+    <main className="page">
+      <h1>Mentions légales</h1>
+    </main>
+  );
+}


### PR DESCRIPTION
## Description

Closes #64

La page `/mentions-legales` retournait une erreur 404. Le lien "Mentions légales" dans le footer pointait vers une route inexistante.

---

## Documentation

### Ce qui a été implémenté
- Créé `frontend/app/mentions-legales/page.tsx` — page Next.js vide avec titre "Mentions légales"

### Choix techniques
- Suivi du pattern des pages existantes (`a-propos/page.tsx`) : metadata + composant minimal avec `className="page"`
- Page volontairement vide comme demandé par le propriétaire du repo

### Comment utiliser
- URL : `/mentions-legales`
- Le lien dans le footer fonctionne désormais sans erreur 404

### Points d'attention
- Aucun — changement isolé sans impact sur le reste de l'application