### PR TITLE
fix: NEXT_PUBLIC_API_URL non résolvable depuis le navigateur headless TNR

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,10 +34,17 @@ MINIO_BUCKET_NAME=media
 MINIO_PUBLIC_URL=http://localhost:9000
 
 # ─── Next.js ───────────────────────────────────────────────────
+# URL publique de l'API, utilisée par le code client (navigateur).
 # Dev    : http://localhost:8000
-# TNR    : http://nginx (résolu via le réseau docker compose)
+# TNR    : (vide — URLs relatives, évite les problèmes DNS du navigateur headless)
 # Prod   : https://culturall-website.nickorp.com
 NEXT_PUBLIC_API_URL=http://localhost:8000
+# URL interne de l'API, utilisée par le middleware SSR de Next.js.
+# Prioritaire sur NEXT_PUBLIC_API_URL côté serveur (voir frontend/middleware.ts).
+# Dev    : (non requis, NEXT_PUBLIC_API_URL suffit)
+# TNR    : http://nginx
+# Prod   : (non requis, NEXT_PUBLIC_API_URL suffit)
+INTERNAL_API_URL=
 NODE_ENV=development
 
 # ─── CI/CD (production uniquement) ─────────────────────────────

--- a/.env.test
+++ b/.env.test
@@ -24,10 +24,13 @@ MINIO_BUCKET_NAME=media
 MINIO_PUBLIC_URL=http://localhost:9000
 
 # ─── Next.js ───────────────────────────────────────────────────
-# Dev    : http://localhost:8000
-# TNR    : http://nginx (résolu via le réseau docker compose)
-# Prod   : https://culturall-website.nickorp.com
-NEXT_PUBLIC_API_URL=http://nginx
+# NEXT_PUBLIC_API_URL est volontairement vide en TNR : les composants
+# client ('use client') utilisent alors des URLs relatives (/api/…),
+# ce qui évite les problèmes de résolution DNS depuis le navigateur
+# headless (Chromium ne résout pas les hostnames Docker).
+NEXT_PUBLIC_API_URL=
+# URL interne (Docker DNS) utilisée par le middleware SSR de Next.js.
+INTERNAL_API_URL=http://nginx
 NODE_ENV=development
 
 # ─── CI/CD (production uniquement) ─────────────────────────────

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -38,6 +38,7 @@ services:
       dockerfile: ../docker/nextjs/Dockerfile
     environment:
       - NEXT_PUBLIC_API_URL
+      - INTERNAL_API_URL
       - NODE_ENV
     depends_on:
       - django


### PR DESCRIPTION
## Description

Closes #65

Le hostname `http://nginx` configuré dans `NEXT_PUBLIC_API_URL` (`.env.test`) n'est pas résolvable depuis le navigateur headless (Chromium) utilisé pour les tests de non-régression. Les appels `fetch()` côté client échouent avec "Failed to fetch".

**Fix :** vider `NEXT_PUBLIC_API_URL` en TNR pour que les composants client utilisent des URLs relatives (`/api/…`), et ajouter `INTERNAL_API_URL=http://nginx` pour la résolution server-side (middleware SSR).

---

## Documentation

**Fichiers modifiés :**
- `.env.test` : `NEXT_PUBLIC_API_URL=` (vide) + `INTERNAL_API_URL=http://nginx`
- `docker-compose.base.yml` : ajout de `INTERNAL_API_URL` à l'environnement `nextjs`
- `.env.example` : documentation de `INTERNAL_API_URL`

**Tests impactés :** CONTACT-02, AUTH-02, AUTH-03, AUTH-04, PROJ-01, NET-01