### PR TITLE
docs: add release notes for week of 2026-04-09

### DIFF
--- a/docs/release-notes/2026-04-12.md
+++ b/docs/release-notes/2026-04-12.md
@@ -1,0 +1,52 @@
+# Release notes — Semaine du 9 au 12 avril 2026
+
+Première semaine de mise en route du site Culturall : la plupart des pages publiques ont été posées, l'espace d'administration rendu utilisable, et les premiers contenus (projets, articles, membres du réseau) peuvent désormais être gérés de bout en bout.
+
+## Nouveautés visibles par les visiteurs
+
+### Page d'accueil
+- Mise en place de la landing page avec la date du jour affichée automatiquement.
+- Nouvelle section **Réseau** présentant les membres, avec ajustements visuels pour une meilleure lisibilité.
+- Nouvelle section **Projets** mettant en avant une sélection sur la homepage.
+- Ajout d'un **carousel des derniers articles** de blog.
+- Version mobile retravaillée : titre en haut à gauche, menu repensé, affichage vertical sous le titre.
+- **Barre de navigation évolutive** qui s'adapte au scroll de la page.
+- Ajout d'un **footer** en bas de toutes les pages.
+
+### Projets
+- Nouvelle page listant l'ensemble des projets (`/projets`), avec miniatures et tri par tag.
+- Description des projets désormais en **texte riche** (mise en forme, liens, etc.).
+- Amélioration de l'affichage lorsqu'un projet n'a pas de vignette.
+
+### Blog
+- Nouvelle page blog listant l'ensemble des articles publiés.
+
+### Contact
+- Ajout d'un **formulaire de contact** fonctionnel.
+- Création d'une page **Mentions légales** (404 corrigé).
+
+### Menu
+- Refonte complète du **menu responsive** avec version mobile en hamburger, fermeture à la touche Échap et gestion du défilement.
+
+### Accès au site
+- Mise en place d'une **protection par mot de passe** pour restreindre l'accès pendant la phase de construction.
+
+## Côté administration (back-office Wagtail)
+
+- **Gestion des projets** : ajout, édition, miniatures, description enrichie.
+- **Gestion des articles de blog** : création et publication depuis l'admin.
+- **Consultation des messages de contact** directement dans l'admin.
+- **Guide d'administration** rédigé avec captures d'écran réelles pour accompagner la prise en main.
+
+## Corrections notables
+
+- Les images s'affichent désormais correctement en production comme en développement.
+- Correction de l'accès à l'administration Wagtail en production.
+- Le formulaire de contact fonctionne sans dépendre d'une URL fixe.
+- La vidéo fixe au scroll, introduite puis jugée non satisfaisante, a été retirée.
+
+## Sous le capot (pour information)
+
+- Mise en place des premiers tests automatisés (unitaires et de non-régression navigateur).
+- Workflow d'auto-correction des erreurs de CI.
+- Jeux de données de démonstration chargés automatiquement avant les tests.


### PR DESCRIPTION
Synthetic, non-technical release notes covering the first week of
development: public pages, admin capabilities, and notable fixes.