### PR TITLE
Fix mobile viewport handling and Django admin setup in TNR

### DIFF
--- a/.claude/skills/browser-tests-on-demand/SKILL.md
+++ b/.claude/skills/browser-tests-on-demand/SKILL.md
@@ -149,6 +149,33 @@ agent-browser --session user1 click @e3
 agent-browser --session user1 wait --load networkidle
 ```
 
+### 3.1.1 Viewport mobile vs desktop
+
+Le viewport par défaut d'`agent-browser` est **1280×720 (desktop)**. Les
+scénarios qui mentionnent « viewport mobile (375px de large) » dans le
+cahier de tests (ex : `NAV-05`, `NAV-06`, `BLOG-08`, `NET-04`, `PROJ-06`,
+`PROJ-07`) **ne déclenchent pas** les media queries `(max-width: 768px)`
+tant que le viewport n'a pas été explicitement réduit — les tests remontent
+alors de faux échecs alors que le comportement est correct sur un vrai
+téléphone.
+
+Avant d'ouvrir la page d'un test « mobile », bascule le viewport de la
+session correspondante, puis reviens en desktop pour les tests suivants :
+
+```bash
+# Passage en mobile
+agent-browser --session {session} set viewport 375 812
+agent-browser --session {session} open "$BASE_URL/..."
+# ... assertions mobiles ...
+
+# Retour en desktop
+agent-browser --session {session} set viewport 1280 720
+```
+
+Le viewport est **persistant par session** : inutile de le redéfinir
+entre deux commandes de la même session tant que le mode (mobile ou
+desktop) ne change pas.
+
 ### 3.2 Exécution d'un scénario
 
 Pour chaque test à exécuter :

--- a/.claude/skills/regression-tests/SKILL.md
+++ b/.claude/skills/regression-tests/SKILL.md
@@ -153,6 +153,34 @@ agent-browser --session user2 open ${BASE_URL}/admin/login/
 **Important :** Réutilise les sessions entre les tests du même type pour
 éviter de se reconnecter à chaque test.
 
+### 2.2.1 Viewport mobile vs desktop
+
+Le viewport par défaut d'`agent-browser` est **1280×720 (desktop)**. Les
+scénarios qui mentionnent « viewport mobile (375px de large) » dans le
+cahier de tests (ex : `NAV-05`, `NAV-06`, `BLOG-08`, `NET-04`, `PROJ-06`,
+`PROJ-07`) **ne déclenchent pas** les media queries `(max-width: 768px)`
+tant que le viewport n'a pas été explicitement réduit. Conséquence
+typique : le menu hamburger n'apparaît pas et la grille blog reste en
+3 colonnes, alors que tout fonctionne sur un vrai téléphone.
+
+Avant chaque test « mobile », bascule le viewport de la session
+correspondante **avant** d'ouvrir la page, puis remets-le en desktop
+après le test (ou en début du test suivant non-mobile) :
+
+```bash
+# Passage en mobile
+agent-browser --session {session} set viewport 375 812
+agent-browser --session {session} open "${BASE_URL}/..."
+# ... assertions mobiles ...
+
+# Retour en desktop après le dernier test mobile consécutif
+agent-browser --session {session} set viewport 1280 720
+```
+
+Le viewport est **persistant par session** : inutile de le redéfinir
+avant chaque commande de la même session tant que le mode (mobile ou
+desktop) ne change pas.
+
 ### 2.3 Exécution d'un test unitaire
 
 Pour chaque scénario, le pattern est :

--- a/docker/nginx/preprod.conf
+++ b/docker/nginx/preprod.conf
@@ -30,6 +30,17 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    # Django admin (distinct de l'admin Wagtail monté sur /admin/).
+    # Exposé en preprod/TNR pour pouvoir inspecter les ContactSubmission,
+    # les users, etc. (cf. CONTACT-04 du cahier de tests).
+    location /django-admin/ {
+        proxy_pass http://django_upstream;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /api/ {
         proxy_pass http://django_upstream;
         proxy_set_header Host $host;

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import './globals.css';
 import Header from './components/Header';
 import Footer from './components/Footer';
@@ -6,6 +6,16 @@ import Footer from './components/Footer';
 export const metadata: Metadata = {
   title: { default: "Cultur'all", template: "%s — Cultur'all" },
   description: "Cultur'all — Site vitrine",
+};
+
+// Sans cette meta, les navigateurs (y compris Chromium headless utilisé par
+// agent-browser / les TNR) utilisent un layout viewport fixe (~980px) même
+// quand la fenêtre fait 375px, ce qui empêche les media queries
+// `(max-width: 768px)` de se déclencher — le menu hamburger et la grille
+// blog mono-colonne restent donc invisibles en TNR.
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata, Viewport } from 'next';
+import type { Metadata } from 'next';
 import './globals.css';
 import Header from './components/Header';
 import Footer from './components/Footer';
@@ -6,16 +6,6 @@ import Footer from './components/Footer';
 export const metadata: Metadata = {
   title: { default: "Cultur'all", template: "%s — Cultur'all" },
   description: "Cultur'all — Site vitrine",
-};
-
-// Sans cette meta, les navigateurs (y compris Chromium headless utilisé par
-// agent-browser / les TNR) utilisent un layout viewport fixe (~980px) même
-// quand la fenêtre fait 375px, ce qui empêche les media queries
-// `(max-width: 768px)` de se déclencher — le menu hamburger et la grille
-// blog mono-colonne restent donc invisibles en TNR.
-export const viewport: Viewport = {
-  width: 'device-width',
-  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/scripts/tnr-docker.sh
+++ b/scripts/tnr-docker.sh
@@ -69,7 +69,15 @@ run_migrations() {
     echo "Running Django/Wagtail migrations..."
     $COMPOSE exec -T django python manage.py migrate --noinput
     echo "Collecting static files..."
-    $COMPOSE exec -T django python manage.py collectstatic --noinput || true
+    $COMPOSE exec -T django python manage.py collectstatic --noinput
+    # Gunicorn a démarré avant collectstatic : WhiteNoise et
+    # CompressedManifestStaticFilesStorage ont donc caché en mémoire
+    # l'absence du dossier /app/staticfiles et du staticfiles.json.
+    # Sans restart, l'admin Wagtail retourne 500 pour toute la durée
+    # de vie du container (cf. régression récurrente sur /admin/ en TNR).
+    echo "Restarting Django so gunicorn picks up the fresh staticfiles manifest..."
+    $COMPOSE restart django
+    wait_for_gunicorn
 }
 
 seed_test_data() {


### PR DESCRIPTION
## Summary
This PR addresses three issues: missing documentation for mobile viewport testing, missing Django admin route exposure in preprod, and a race condition in static files collection during Docker setup.

## Key Changes

- **Mobile viewport testing documentation**: Added comprehensive sections to both regression-tests and browser-tests-on-demand skill docs explaining that `agent-browser` defaults to 1280×720 (desktop) viewport. Tests marked as "mobile (375px)" in the test spec must explicitly set viewport to 375×812 before opening the page, then reset to desktop afterward. Clarifies that viewport is persistent per session.

- **Django admin route exposure**: Added `/django-admin/` location block to nginx preprod config to expose Django's admin interface (distinct from Wagtail's `/admin/`). This enables test inspection of ContactSubmission records and user data as required by test spec (CONTACT-04).

- **Static files collection race condition fix**: Modified `tnr-docker.sh` to restart the Django container after `collectstatic` completes. Gunicorn starts before static files are collected, causing WhiteNoise and CompressedManifestStaticFilesStorage to cache the absence of `/app/staticfiles` and `staticfiles.json` in memory. Without restart, the Wagtail admin returns 500 errors for the container's entire lifetime.

## Implementation Details

- The viewport documentation includes concrete bash examples showing the pattern: set viewport → open page → run assertions → reset viewport
- Django admin proxy configuration mirrors the existing `/admin/` block with appropriate headers
- The Gunicorn restart is followed by `wait_for_gunicorn` to ensure the service is ready before proceeding

https://claude.ai/code/session_01NjstCd9RsYDcvVomK1Diy9