### PR TITLE
fix: enforce max 3 featured projects on save

### DIFF
--- a/backend/projects/models.py
+++ b/backend/projects/models.py
@@ -68,3 +68,7 @@ class Project(ClusterableModel):
                 raise ValidationError(
                     {"featured": f"Il ne peut y avoir plus de {MAX_FEATURED_PROJECTS} projets à la une."}
                 )
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)

--- a/backend/projects/tests/test_projects.py
+++ b/backend/projects/tests/test_projects.py
@@ -123,6 +123,24 @@ class TestProjectModel:
             extra.clean()
         assert "featured" in exc_info.value.message_dict
 
+    def test_featured_max_validation_on_save(self, db):
+        """save() must also enforce the max featured constraint."""
+        for i in range(MAX_FEATURED_PROJECTS):
+            Project.objects.create(
+                title=f"Featured {i}",
+                youtube_url=f"https://youtube.com/watch?v={i}",
+                featured=True,
+            )
+        extra = Project(
+            title="One too many",
+            youtube_url="https://youtube.com/watch?v=extra",
+            featured=True,
+        )
+        with pytest.raises(ValidationError) as exc_info:
+            extra.save()
+        assert "featured" in exc_info.value.message_dict
+        assert Project.objects.filter(featured=True).count() == MAX_FEATURED_PROJECTS
+
     def test_featured_allows_update_existing(self, db):
         project = Project.objects.create(
             title="Already featured",
@@ -136,4 +154,4 @@ class TestProjectModel:
                 featured=True,
             )
         # Re-saving an existing featured project should not raise
-        project.clean()
+        project.save()


### PR DESCRIPTION
## Description

Closes #80

Le modèle `Project` avait une validation `clean()` pour limiter à 3 projets « À la une », mais `Model.save()` n'appelle pas `clean()` par défaut en Django. Cela permettait à certains chemins de sauvegarde de contourner la contrainte.

### Changements

- **`backend/projects/models.py`** : override `save()` pour appeler `clean()` avant chaque sauvegarde
- **`backend/projects/tests/test_projects.py`** : ajout de `test_featured_max_validation_on_save` + mise à jour de `test_featured_allows_update_existing` pour tester via `save()`

---

## Documentation

### Choix techniques
- Override `save()` plutôt que validation au niveau form : garantit la contrainte quel que soit le chemin de sauvegarde (admin, ORM, management commands)
- Pas de contrainte DB : les CHECK constraints cross-row ne sont pas supportées nativement

### Tests
- 66 tests backend passent (13 dans le module projects)
- Le test `test_featured_max_validation_on_save` vérifie spécifiquement que `save()` refuse un 4e projet featured