### PR TITLE
feat: harmoniser le détail des projets avec celui des articles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ frontend/node_modules/
 __pycache__/
 *.pyc
 .pytest_cache/
+frontend/tsconfig.tsbuildinfo

--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -230,16 +230,21 @@ Types d'accès :
 
 **Résultat attendu** : la page Projets affiche une grille 3 colonnes avec filtrage par tags fonctionnel.
 
-### PROJ-03 [PUBLIC] — Clic sur un projet ouvre la vue détail
+### PROJ-03 [PUBLIC] — Clic sur un projet ouvre l'overlay détail (même pattern que les articles)
 1. Ouvrir `${BASE_URL}/projets`
 2. Cliquer sur une carte de projet
-3. Vérifier que la vue détail s'ouvre avec les informations textuelles (titre, description en texte riche, tags)
-4. Vérifier que la vidéo YouTube intégrée est affichée
-5. Vérifier la présence du lien « Retour aux projets »
-6. Cliquer sur « Retour aux projets »
-7. Vérifier le retour à la grille de projets
+3. Vérifier que l'overlay s'ouvre en plein écran avec un fond semi-opaque
+4. Vérifier la présence du bouton de fermeture (✕) en haut à droite
+5. Vérifier que le titre du projet est affiché
+6. Vérifier que les tags du projet sont affichés
+7. Vérifier que la description en texte riche est affichée
+8. Vérifier que la vidéo YouTube intégrée est affichée
+9. Fermer l'overlay via le bouton ✕
+10. Vérifier le retour à la grille de projets
+11. Rouvrir un projet et fermer via la touche Échap
+12. Vérifier le retour à la grille de projets
 
-**Résultat attendu** : la vue détail s'ouvre avec les informations et la vidéo, retour fonctionnel à la grille.
+**Résultat attendu** : l'overlay projet s'ouvre en plein écran avec titre, tags, description et vidéo, fermeture fonctionnelle via ✕ et Échap.
 
 ### PROJ-04 [AUTH] — Champ « À la une » dans l'admin Wagtail
 1. Se connecter à `${BASE_URL}/admin/`
@@ -285,10 +290,11 @@ Types d'accès :
 5. Cliquer sur « Voir tous les projets »
 6. Vérifier la navigation vers `${BASE_URL}/projets`
 7. Vérifier la présence du projet créé dans la grille
-8. Cliquer sur le projet pour voir la vue détail
-9. Vérifier les informations et la vidéo
+8. Cliquer sur le projet pour ouvrir l'overlay détail
+9. Vérifier les informations (titre, tags, description) et la vidéo YouTube dans l'overlay
+10. Fermer l'overlay via le bouton ✕
 
-**Résultat attendu** : parcours complet de création et consultation d'un projet via la homepage et la page projets sans erreur.
+**Résultat attendu** : parcours complet de création et consultation d'un projet via la homepage et la page projets sans erreur, overlay fonctionnel.
 
 ## 6. Section Réseau
 

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ArticleOverlay, { Article } from '../components/ArticleOverlay';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
@@ -15,6 +15,7 @@ export default function BlogPage() {
   const [loading, setLoading] = useState(true);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [selectedArticle, setSelectedArticle] = useState<Article | null>(null);
+  const clearSelection = useCallback(() => setSelectedArticle(null), []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -107,7 +108,7 @@ export default function BlogPage() {
         </div>
       )}
 
-      <ArticleOverlay article={selectedArticle} onClose={() => setSelectedArticle(null)} />
+      <ArticleOverlay article={selectedArticle} onClose={clearSelection} />
     </div>
   );
 }

--- a/frontend/app/components/ArticleOverlay.tsx
+++ b/frontend/app/components/ArticleOverlay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useOverlay } from '../hooks/useOverlay';
 
 export interface Article {
   id: number;
@@ -18,78 +18,42 @@ interface ArticleOverlayProps {
 }
 
 export default function ArticleOverlay({ article, onClose }: ArticleOverlayProps) {
-  const [visible, setVisible] = useState(false);
-  const rafRef = useRef<number>(0);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
-
-  const handleClose = useCallback(() => {
-    setVisible(false);
-    clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(onClose, 400);
-  }, [onClose]);
-
-  useEffect(() => {
-    if (article) {
-      rafRef.current = requestAnimationFrame(() => setVisible(true));
-      document.body.style.overflow = 'hidden';
-      return () => {
-        cancelAnimationFrame(rafRef.current);
-        clearTimeout(timeoutRef.current);
-        document.body.style.overflow = '';
-      };
-    } else {
-      setVisible(false);
-      document.body.style.overflow = '';
-    }
-  }, [article]);
-
-  useEffect(() => {
-    if (!article) return;
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') handleClose();
-    }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [article, handleClose]);
-
-  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
-    if (e.target === e.currentTarget) handleClose();
-  }
+  const { visible, handleClose, handleBackdropClick } = useOverlay(!!article, onClose);
 
   if (!article) return null;
 
   return (
     <div
-      className={`article-overlay ${visible ? 'article-overlay--visible' : ''}`}
+      className={`content-overlay ${visible ? 'content-overlay--visible' : ''}`}
       role="dialog"
       aria-modal="true"
       aria-labelledby="article-overlay-title"
       onClick={handleBackdropClick}
     >
-      <button className="article-overlay__close" onClick={handleClose} aria-label="Fermer">
+      <button className="content-overlay__close" onClick={handleClose} aria-label="Fermer">
         ✕
       </button>
-      <div className="article-overlay__content">
+      <div className="content-overlay__content">
         {article.illustration_url && (
           <img
             src={article.illustration_url}
             alt=""
-            className="article-overlay__illustration"
+            className="content-overlay__illustration"
           />
         )}
-        <h2 id="article-overlay-title" className="article-overlay__title">{article.title}</h2>
+        <h2 id="article-overlay-title" className="content-overlay__title">{article.title}</h2>
         {article.tags.length > 0 && (
-          <div className="article-overlay__tags">
+          <div className="content-overlay__tags">
             {article.tags.map((tag, i) => (
-              <span key={`${tag}-${i}`} className="article-overlay__tag">{tag}</span>
+              <span key={`${tag}-${i}`} className="content-overlay__tag">{tag}</span>
             ))}
           </div>
         )}
         {article.summary && (
-          <p className="article-overlay__summary">{article.summary}</p>
+          <p className="content-overlay__summary">{article.summary}</p>
         )}
         <div
-          className="article-overlay__body"
+          className="content-overlay__body"
           dangerouslySetInnerHTML={{ __html: article.content }}
         />
       </div>

--- a/frontend/app/components/ProjectOverlay.tsx
+++ b/frontend/app/components/ProjectOverlay.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface Project {
+  id: number;
+  title: string;
+  description: string;
+  youtube_url: string;
+  tags: string[];
+  thumbnail_url: string | null;
+}
+
+interface ProjectOverlayProps {
+  project: Project | null;
+  onClose: () => void;
+}
+
+function extractYouTubeId(url: string): string | null {
+  const match = url.match(
+    /(?:youtu\.be\/|youtube\.com\/(?:watch\?.*v=|embed\/|shorts\/))([a-zA-Z0-9_-]{11})/,
+  );
+  return match ? match[1] : null;
+}
+
+export default function ProjectOverlay({ project, onClose }: ProjectOverlayProps) {
+  const [visible, setVisible] = useState(false);
+  const rafRef = useRef<number>(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const handleClose = useCallback(() => {
+    setVisible(false);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(onClose, 400);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (project) {
+      rafRef.current = requestAnimationFrame(() => setVisible(true));
+      document.body.style.overflow = 'hidden';
+      return () => {
+        cancelAnimationFrame(rafRef.current);
+        clearTimeout(timeoutRef.current);
+        document.body.style.overflow = '';
+      };
+    } else {
+      setVisible(false);
+      document.body.style.overflow = '';
+    }
+  }, [project]);
+
+  useEffect(() => {
+    if (!project) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [project, handleClose]);
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) handleClose();
+  }
+
+  if (!project) return null;
+
+  const videoId = extractYouTubeId(project.youtube_url);
+
+  return (
+    <div
+      className={`article-overlay ${visible ? 'article-overlay--visible' : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="project-overlay-title"
+      onClick={handleBackdropClick}
+    >
+      <button className="article-overlay__close" onClick={handleClose} aria-label="Fermer">
+        ✕
+      </button>
+      <div className="article-overlay__content">
+        <h2 id="project-overlay-title" className="article-overlay__title">{project.title}</h2>
+        {project.tags.length > 0 && (
+          <div className="article-overlay__tags">
+            {project.tags.map((tag, i) => (
+              <span key={`${tag}-${i}`} className="article-overlay__tag">{tag}</span>
+            ))}
+          </div>
+        )}
+        <div
+          className="article-overlay__body"
+          dangerouslySetInnerHTML={{ __html: project.description }}
+        />
+        {videoId && (
+          <div className="project-overlay__video">
+            <iframe
+              src={`https://www.youtube.com/embed/${videoId}`}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+              sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+              loading="lazy"
+              allowFullScreen
+              title={project.title}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/components/ProjectOverlay.tsx
+++ b/frontend/app/components/ProjectOverlay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useOverlay } from '../hooks/useOverlay';
 
 export interface Project {
   id: number;
@@ -24,43 +24,7 @@ function extractYouTubeId(url: string): string | null {
 }
 
 export default function ProjectOverlay({ project, onClose }: ProjectOverlayProps) {
-  const [visible, setVisible] = useState(false);
-  const rafRef = useRef<number>(0);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
-
-  const handleClose = useCallback(() => {
-    setVisible(false);
-    clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(onClose, 400);
-  }, [onClose]);
-
-  useEffect(() => {
-    if (project) {
-      rafRef.current = requestAnimationFrame(() => setVisible(true));
-      document.body.style.overflow = 'hidden';
-      return () => {
-        cancelAnimationFrame(rafRef.current);
-        clearTimeout(timeoutRef.current);
-        document.body.style.overflow = '';
-      };
-    } else {
-      setVisible(false);
-      document.body.style.overflow = '';
-    }
-  }, [project]);
-
-  useEffect(() => {
-    if (!project) return;
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') handleClose();
-    }
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [project, handleClose]);
-
-  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
-    if (e.target === e.currentTarget) handleClose();
-  }
+  const { visible, handleClose, handleBackdropClick } = useOverlay(!!project, onClose);
 
   if (!project) return null;
 
@@ -68,26 +32,26 @@ export default function ProjectOverlay({ project, onClose }: ProjectOverlayProps
 
   return (
     <div
-      className={`article-overlay ${visible ? 'article-overlay--visible' : ''}`}
+      className={`content-overlay ${visible ? 'content-overlay--visible' : ''}`}
       role="dialog"
       aria-modal="true"
       aria-labelledby="project-overlay-title"
       onClick={handleBackdropClick}
     >
-      <button className="article-overlay__close" onClick={handleClose} aria-label="Fermer">
+      <button className="content-overlay__close" onClick={handleClose} aria-label="Fermer">
         ✕
       </button>
-      <div className="article-overlay__content">
-        <h2 id="project-overlay-title" className="article-overlay__title">{project.title}</h2>
+      <div className="content-overlay__content">
+        <h2 id="project-overlay-title" className="content-overlay__title">{project.title}</h2>
         {project.tags.length > 0 && (
-          <div className="article-overlay__tags">
+          <div className="content-overlay__tags">
             {project.tags.map((tag, i) => (
-              <span key={`${tag}-${i}`} className="article-overlay__tag">{tag}</span>
+              <span key={`${tag}-${i}`} className="content-overlay__tag">{tag}</span>
             ))}
           </div>
         )}
         <div
-          className="article-overlay__body"
+          className="content-overlay__body"
           dangerouslySetInnerHTML={{ __html: project.description }}
         />
         {videoId && (

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -572,7 +572,7 @@ body {
 }
 
 /* Article overlay */
-.article-overlay {
+.content-overlay {
   position: fixed;
   inset: 0;
   z-index: 100;
@@ -586,12 +586,12 @@ body {
   pointer-events: none;
 }
 
-.article-overlay--visible {
+.content-overlay--visible {
   opacity: 1;
   pointer-events: auto;
 }
 
-.article-overlay__close {
+.content-overlay__close {
   position: absolute;
   top: 1.5rem;
   right: 2rem;
@@ -604,17 +604,17 @@ body {
   transition: opacity 0.2s;
 }
 
-.article-overlay__close:hover {
+.content-overlay__close:hover {
   opacity: 0.7;
 }
 
-.article-overlay__content {
+.content-overlay__content {
   max-width: 800px;
   width: 100%;
   padding: 4rem 2rem 3rem;
 }
 
-.article-overlay__illustration {
+.content-overlay__illustration {
   width: 100%;
   max-height: 400px;
   object-fit: cover;
@@ -622,21 +622,21 @@ body {
   margin-bottom: 2rem;
 }
 
-.article-overlay__title {
+.content-overlay__title {
   font-size: 2.5rem;
   font-weight: 700;
   margin: 0 0 1rem;
   color: #fff;
 }
 
-.article-overlay__tags {
+.content-overlay__tags {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
   margin-bottom: 1.5rem;
 }
 
-.article-overlay__tag {
+.content-overlay__tag {
   padding: 0.25rem 0.75rem;
   background: rgba(255, 255, 255, 0.1);
   border-radius: 2rem;
@@ -645,7 +645,7 @@ body {
   letter-spacing: 0.05em;
 }
 
-.article-overlay__summary {
+.content-overlay__summary {
   font-size: 1.15rem;
   font-style: italic;
   opacity: 0.75;
@@ -653,33 +653,33 @@ body {
   line-height: 1.6;
 }
 
-.article-overlay__body {
+.content-overlay__body {
   font-size: 1.1rem;
   line-height: 1.7;
   opacity: 0.85;
 }
 
-.article-overlay__body p {
+.content-overlay__body p {
   margin: 0 0 0.75em;
 }
 
-.article-overlay__body p:last-child {
+.content-overlay__body p:last-child {
   margin-bottom: 0;
 }
 
-.article-overlay__body ul,
-.article-overlay__body ol {
+.content-overlay__body ul,
+.content-overlay__body ol {
   margin: 0 0 0.75em;
   padding-left: 1.5em;
 }
 
-.article-overlay__body a {
+.content-overlay__body a {
   color: #fff;
   text-decoration: underline;
   text-underline-offset: 0.15em;
 }
 
-.article-overlay__body a:hover {
+.content-overlay__body a:hover {
   opacity: 0.7;
 }
 
@@ -1044,11 +1044,11 @@ body {
   }
 
   /* Article overlay mobile */
-  .article-overlay__content {
+  .content-overlay__content {
     padding: 3.5rem 1.5rem 2rem;
   }
 
-  .article-overlay__title {
+  .content-overlay__title {
     font-size: 1.75rem;
   }
 

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -474,113 +474,14 @@ body {
   background: rgba(255, 255, 255, 0.14);
 }
 
-/* Project detail */
-.project-detail {
-  display: flex;
-  flex-direction: column;
-  background: #111;
-  color: #fff;
-  opacity: 0;
-  transform: scale(0.95);
-  transition: opacity 0.4s ease, transform 0.4s ease;
-  min-height: 60vh;
-}
-
-.project-detail--visible {
-  opacity: 1;
-  transform: scale(1);
-}
-
-.project-detail__back {
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 1rem;
-  cursor: pointer;
-  padding: 1.5rem 2rem;
-  align-self: flex-start;
-  transition: opacity 0.2s;
-  font-family: inherit;
-}
-
-.project-detail__back:hover {
-  opacity: 0.7;
-}
-
-.project-detail__content {
-  display: flex;
-  flex: 1;
-  padding: 0 3rem 3rem;
-  gap: 3rem;
-  align-items: flex-start;
-}
-
-.project-detail__info {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.project-detail__title {
-  font-size: 2.5rem;
-  font-weight: 700;
-  margin: 0;
-}
-
-.project-detail__tags {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.project-detail__tag {
-  padding: 0.25rem 0.75rem;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 2rem;
-  font-size: 0.85rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
-
-.project-detail__description {
-  font-size: 1.1rem;
-  line-height: 1.7;
-  opacity: 0.85;
-  margin: 0;
-}
-
-.project-detail__description p {
-  margin: 0 0 0.75em;
-}
-
-.project-detail__description p:last-child {
-  margin-bottom: 0;
-}
-
-.project-detail__description ul,
-.project-detail__description ol {
-  margin: 0 0 0.75em;
-  padding-left: 1.5em;
-}
-
-.project-detail__description a {
-  color: #fff;
-  text-decoration: underline;
-  text-underline-offset: 0.15em;
-}
-
-.project-detail__description a:hover {
-  opacity: 0.7;
-}
-
-.project-detail__video {
-  flex: 1;
+/* Project overlay video */
+.project-overlay__video {
+  width: 100%;
   aspect-ratio: 16 / 9;
-  min-height: 300px;
+  margin-top: 2rem;
 }
 
-.project-detail__video iframe {
+.project-overlay__video iframe {
   width: 100%;
   height: 100%;
   border: none;
@@ -1065,15 +966,6 @@ body {
 
   .page {
     padding-top: 5rem;
-  }
-
-  .project-detail__content {
-    flex-direction: column;
-    padding: 0 1.5rem 2rem;
-  }
-
-  .project-detail__video {
-    width: 100%;
   }
 
   .projets-grid {

--- a/frontend/app/hooks/useOverlay.ts
+++ b/frontend/app/hooks/useOverlay.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function useOverlay(isOpen: boolean, onClose: () => void) {
+  const [visible, setVisible] = useState(false);
+  const rafRef = useRef<number>(0);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const handleClose = useCallback(() => {
+    setVisible(false);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(onClose, 400);
+  }, [onClose]);
+
+  useEffect(() => {
+    if (isOpen) {
+      rafRef.current = requestAnimationFrame(() => setVisible(true));
+      document.body.style.overflow = 'hidden';
+      return () => {
+        cancelAnimationFrame(rafRef.current);
+        clearTimeout(timeoutRef.current);
+        document.body.style.overflow = '';
+      };
+    } else {
+      setVisible(false);
+      document.body.style.overflow = '';
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, handleClose]);
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (e.target === e.currentTarget) handleClose();
+  }
+
+  return { visible, handleClose, handleBackdropClick };
+}

--- a/frontend/app/projets/page.tsx
+++ b/frontend/app/projets/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState, useEffect } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import ProjectOverlay, { Project } from '../components/ProjectOverlay';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
@@ -10,6 +10,7 @@ export default function ProjetsPage() {
   const [loading, setLoading] = useState(true);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
+  const clearSelection = useCallback(() => setSelectedProject(null), []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -95,7 +96,7 @@ export default function ProjetsPage() {
         </div>
       )}
 
-      <ProjectOverlay project={selectedProject} onClose={() => setSelectedProject(null)} />
+      <ProjectOverlay project={selectedProject} onClose={clearSelection} />
     </div>
   );
 }

--- a/frontend/app/projets/page.tsx
+++ b/frontend/app/projets/page.tsx
@@ -1,22 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
-
-interface Project {
-  id: number;
-  title: string;
-  description: string;
-  youtube_url: string;
-  tags: string[];
-  thumbnail_url: string | null;
-}
-
-function extractYouTubeId(url: string): string | null {
-  const match = url.match(
-    /(?:youtu\.be\/|youtube\.com\/(?:watch\?.*v=|embed\/|shorts\/))([a-zA-Z0-9_-]{11})/,
-  );
-  return match ? match[1] : null;
-}
+import { useMemo, useState, useEffect } from 'react';
+import ProjectOverlay, { Project } from '../components/ProjectOverlay';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
@@ -25,7 +10,6 @@ export default function ProjetsPage() {
   const [loading, setLoading] = useState(true);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-  const [detailVisible, setDetailVisible] = useState(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -47,16 +31,6 @@ export default function ProjetsPage() {
     return () => controller.abort();
   }, []);
 
-  const handleSelectProject = useCallback((project: Project) => {
-    setSelectedProject(project);
-    requestAnimationFrame(() => setDetailVisible(true));
-  }, []);
-
-  const handleBackToList = useCallback(() => {
-    setDetailVisible(false);
-    setTimeout(() => setSelectedProject(null), 400);
-  }, []);
-
   const allTags = useMemo(
     () => Array.from(new Set(projects.flatMap((p) => p.tags))).sort(),
     [projects],
@@ -66,98 +40,62 @@ export default function ProjetsPage() {
     [projects, selectedTag],
   );
 
-  const videoId = selectedProject ? extractYouTubeId(selectedProject.youtube_url) : null;
-
   return (
     <div className="page projets-page">
-      {!selectedProject ? (
-        <>
-          <h1>Nos Projets</h1>
+      <h1>Nos Projets</h1>
 
-          {allTags.length > 0 && (
-            <div className="projects-filters">
-              <button
-                className={`projects-filters__btn${selectedTag === null ? ' projects-filters__btn--active' : ''}`}
-                onClick={() => setSelectedTag(null)}
-              >
-                Tous
-              </button>
-              {allTags.map((tag) => (
-                <button
-                  key={tag}
-                  className={`projects-filters__btn${selectedTag === tag ? ' projects-filters__btn--active' : ''}`}
-                  onClick={() => setSelectedTag(tag)}
-                >
-                  {tag}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {loading ? (
-            <p className="projets-page__message">Chargement…</p>
-          ) : filtered.length === 0 ? (
-            <p className="projets-page__message">Aucun projet pour le moment.</p>
-          ) : (
-            <div className="projets-grid">
-              {filtered.map((project) => (
-                <button
-                  key={project.id}
-                  className={`project-card${!project.thumbnail_url ? ' project-card--no-thumbnail' : ''}`}
-                  onClick={() => handleSelectProject(project)}
-                >
-                  {project.thumbnail_url && (
-                    <>
-                      <img
-                        src={project.thumbnail_url}
-                        alt=""
-                        className="project-card__thumbnail"
-                      />
-                      <div className="project-card__overlay" />
-                    </>
-                  )}
-                  <span className="project-card__tag">
-                    {project.tags[0] || ''}
-                  </span>
-                  <span className="project-card__title">{project.title}</span>
-                </button>
-              ))}
-            </div>
-          )}
-        </>
-      ) : (
-        <div className={`project-detail${detailVisible ? ' project-detail--visible' : ''}`}>
-          <button className="project-detail__back" onClick={handleBackToList}>
-            ← Retour aux projets
+      {allTags.length > 0 && (
+        <div className="projects-filters">
+          <button
+            className={`projects-filters__btn${selectedTag === null ? ' projects-filters__btn--active' : ''}`}
+            onClick={() => setSelectedTag(null)}
+          >
+            Tous
           </button>
-          <div className="project-detail__content">
-            <div className="project-detail__info">
-              <h2 className="project-detail__title">{selectedProject.title}</h2>
-              <div className="project-detail__tags">
-                {selectedProject.tags.map((tag, index) => (
-                  <span key={`${tag}-${index}`} className="project-detail__tag">{tag}</span>
-                ))}
-              </div>
-              <div
-                className="project-detail__description"
-                dangerouslySetInnerHTML={{ __html: selectedProject.description }}
-              />
-            </div>
-            <div className="project-detail__video">
-              {videoId && (
-                <iframe
-                  src={`https://www.youtube.com/embed/${videoId}`}
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
-                  sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
-                  loading="lazy"
-                  allowFullScreen
-                  title={selectedProject.title}
-                />
-              )}
-            </div>
-          </div>
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              className={`projects-filters__btn${selectedTag === tag ? ' projects-filters__btn--active' : ''}`}
+              onClick={() => setSelectedTag(tag)}
+            >
+              {tag}
+            </button>
+          ))}
         </div>
       )}
+
+      {loading ? (
+        <p className="projets-page__message">Chargement…</p>
+      ) : filtered.length === 0 ? (
+        <p className="projets-page__message">Aucun projet pour le moment.</p>
+      ) : (
+        <div className="projets-grid">
+          {filtered.map((project) => (
+            <button
+              key={project.id}
+              className={`project-card${!project.thumbnail_url ? ' project-card--no-thumbnail' : ''}`}
+              onClick={() => setSelectedProject(project)}
+            >
+              {project.thumbnail_url && (
+                <>
+                  <img
+                    src={project.thumbnail_url}
+                    alt=""
+                    className="project-card__thumbnail"
+                  />
+                  <div className="project-card__overlay" />
+                </>
+              )}
+              <span className="project-card__tag">
+                {project.tags[0] || ''}
+              </span>
+              <span className="project-card__title">{project.title}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      <ProjectOverlay project={selectedProject} onClose={() => setSelectedProject(null)} />
     </div>
   );
 }


### PR DESCRIPTION
## Description

Closes #83

Remplace l'affichage inline du détail projet par un overlay modal identique à celui des articles (`ArticleOverlay` pattern).

---

## Documentation

### Ce qui a été implémenté

**Nouveau fichier :**
- `frontend/app/components/ProjectOverlay.tsx` — Composant overlay modal pour le détail projet

**Fichiers modifiés :**
- `frontend/app/projets/page.tsx` — Simplifié : grille toujours visible, overlay en parallèle
- `frontend/app/globals.css` — Suppression CSS `.project-detail*`, ajout `.project-overlay__video`

### Choix techniques

- Réutilisation des classes CSS `article-overlay` pour garantir une apparence identique
- Même pattern d'interaction : fermeture via ✕, Échap ou clic backdrop, body scroll lock
- La grille reste toujours montée, l'overlay s'affiche par-dessus

### Comment vérifier

1. Ouvrir `/projets`
2. Cliquer sur une carte → overlay avec titre, tags, description et vidéo YouTube
3. Fermer via ✕, Échap ou clic hors contenu