### PR TITLE
feat: ajustement show projet

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -233,21 +233,21 @@ Types d'accès :
 ### PROJ-03 [PUBLIC] — Clic sur un projet ouvre l'overlay détail (même pattern que les articles)
 1. Ouvrir `${BASE_URL}/projets`
 2. Cliquer sur une carte de projet
-3. Vérifier que l'overlay s'ouvre en plein écran avec un fond semi-opaque
+3. Vérifier que l'overlay s'ouvre en plein écran avec un fond suffisamment opaque pour lire le contenu
 4. Vérifier la présence du bouton de fermeture (✕) en haut à droite
 5. Vérifier que le titre du projet est affiché
 6. Vérifier que les tags du projet sont affichés
-7. Vérifier que l'année de création est affichée (si renseignée)
-8. Vérifier que la durée de la vidéo est affichée (si renseignée)
-9. Vérifier que la description en texte riche est affichée
-10. Vérifier que les crédits en texte riche sont affichés (si renseignés)
+7. Vérifier que l'année est affichée avec le label « Année » devant (si renseignée)
+8. Vérifier que la durée est affichée avec le label « Durée » devant (si renseignée)
+9. Vérifier que les crédits en texte riche sont affichés **au-dessus** de la description (si renseignés)
+10. Vérifier que la description en texte riche est affichée **en dessous** des crédits
 11. Vérifier que la vidéo YouTube intégrée est affichée
 12. Fermer l'overlay via le bouton ✕
 13. Vérifier le retour à la grille de projets
 14. Rouvrir un projet et fermer via la touche Échap
 15. Vérifier le retour à la grille de projets
 
-**Résultat attendu** : l'overlay projet s'ouvre en plein écran avec titre, tags, année, durée, description, crédits et vidéo, fermeture fonctionnelle via ✕ et Échap.
+**Résultat attendu** : l'overlay projet s'ouvre en plein écran avec titre, tags, « Année » + année, « Durée » + durée, crédits au-dessus de la description, vidéo, fond lisible, fermeture fonctionnelle via ✕ et Échap.
 
 ### PROJ-08 [PUBLIC] — Les champs année, durée et crédits ne sont pas visibles dans les listes
 1. Ouvrir `${BASE_URL}/`

--- a/frontend/app/components/ProjectOverlay.tsx
+++ b/frontend/app/components/ProjectOverlay.tsx
@@ -55,20 +55,20 @@ export default function ProjectOverlay({ project, onClose }: ProjectOverlayProps
         )}
         {(project.year || project.video_duration) && (
           <div className="content-overlay__meta">
-            {project.year && <span className="content-overlay__meta-item">{project.year}</span>}
-            {project.video_duration && <span className="content-overlay__meta-item">{project.video_duration}</span>}
+            {project.year && <span className="content-overlay__meta-item">Année {project.year}</span>}
+            {project.video_duration && <span className="content-overlay__meta-item">Durée {project.video_duration}</span>}
           </div>
         )}
-        <div
-          className="content-overlay__body"
-          dangerouslySetInnerHTML={{ __html: project.description }}
-        />
         {project.credits && (
           <div
             className="content-overlay__credits"
             dangerouslySetInnerHTML={{ __html: project.credits }}
           />
         )}
+        <div
+          className="content-overlay__body"
+          dangerouslySetInnerHTML={{ __html: project.description }}
+        />
         {videoId && (
           <div className="project-overlay__video">
             <iframe

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -612,6 +612,9 @@ body {
   max-width: 800px;
   width: 100%;
   padding: 4rem 2rem 3rem;
+  background: rgba(0, 0, 0, 0.75);
+  border-radius: 0.5rem;
+  margin: 2rem 0;
 }
 
 .content-overlay__illustration {
@@ -666,7 +669,7 @@ body {
 }
 
 .content-overlay__credits {
-  margin: 2rem 0 0;
+  margin: 0 0 1.5rem;
   font-size: 0.95rem;
   line-height: 1.6;
   opacity: 0.7;


### PR DESCRIPTION
## Description

Closes #89

3 ajustements sur l'overlay de détail projet :
- Ajout des labels « Année » et « Durée » devant les valeurs de métadonnées
- Fond de l'article plus opaque (`rgba(0,0,0,0.75)`) pour améliorer la lisibilité
- Crédits affichés au-dessus de la description

---

## Documentation

**Fichiers modifiés :**
- `frontend/app/components/ProjectOverlay.tsx` : labels métadonnées + réordonnancement crédits/description
- `frontend/app/globals.css` : fond opaque sur `.content-overlay__content`, ajustement margin crédits
- `docs/browser-test-checklist.md` : mise à jour PROJ-03 pour refléter les changements

**Ordre d'affichage dans l'overlay :** titre → tags → Année/Durée → crédits → description → vidéo