### PR TITLE
feat: ajout effet de redisposition sur les listes

### DIFF
--- a/docs/browser-test-checklist.md
+++ b/docs/browser-test-checklist.md
@@ -224,11 +224,13 @@ Types d'accès :
 4. Vérifier que chaque carte affiche la miniature en fond, le titre en surimpression et le tag
 5. Vérifier la présence de boutons de filtrage par tags au-dessus de la grille
 6. Cliquer sur un tag spécifique
-7. Vérifier que seuls les projets ayant ce tag sont affichés
-8. Cliquer sur « Tous »
-9. Vérifier que tous les projets sont de nouveau affichés
+7. Vérifier que les cartes se redisposent avec un effet d'animation fluide (fade-in + scale)
+8. Vérifier que seuls les projets ayant ce tag sont affichés
+9. Cliquer sur « Tous »
+10. Vérifier que les cartes se redisposent à nouveau avec l'effet d'animation
+11. Vérifier que tous les projets sont de nouveau affichés
 
-**Résultat attendu** : la page Projets affiche une grille 3 colonnes avec filtrage par tags fonctionnel.
+**Résultat attendu** : la page Projets affiche une grille 3 colonnes avec filtrage par tags fonctionnel et un effet d'animation de redisposition lors du changement de filtre.
 
 ### PROJ-03 [PUBLIC] — Clic sur un projet ouvre l'overlay détail (même pattern que les articles)
 1. Ouvrir `${BASE_URL}/projets`
@@ -326,11 +328,13 @@ Types d'accès :
 3. Vérifier la présence de boutons de filtrage par type au-dessus de la grille de logos
 4. Vérifier qu'un bouton « Tous » est actif par défaut
 5. Cliquer sur un type spécifique
-6. Vérifier que seuls les logos des membres de ce type sont affichés
-7. Cliquer sur « Tous »
-8. Vérifier que tous les logos sont de nouveau affichés
+6. Vérifier que les cartes se redisposent avec un effet d'animation fluide (fade-in + scale)
+7. Vérifier que seuls les logos des membres de ce type sont affichés
+8. Cliquer sur « Tous »
+9. Vérifier que les cartes se redisposent à nouveau avec l'effet d'animation
+10. Vérifier que tous les logos sont de nouveau affichés
 
-**Résultat attendu** : le filtrage par type fonctionne dynamiquement, seuls les logos correspondants sont affichés.
+**Résultat attendu** : le filtrage par type fonctionne dynamiquement avec un effet d'animation de redisposition, seuls les logos correspondants sont affichés.
 
 ### NET-03 [AUTH] — Ajout d'un membre du réseau via l'admin Wagtail
 1. Se connecter à `${BASE_URL}/admin/`
@@ -388,11 +392,13 @@ Types d'accès :
 2. Vérifier la présence de boutons de filtrage par tags au-dessus de la grille
 3. Vérifier qu'un bouton « Tous » est actif par défaut
 4. Cliquer sur un tag spécifique
-5. Vérifier que seuls les articles ayant ce tag sont affichés
-6. Cliquer sur « Tous »
-7. Vérifier que tous les articles sont de nouveau affichés
+5. Vérifier que les cartes se redisposent avec un effet d'animation fluide (fade-in + scale)
+6. Vérifier que seuls les articles ayant ce tag sont affichés
+7. Cliquer sur « Tous »
+8. Vérifier que les cartes se redisposent à nouveau avec l'effet d'animation
+9. Vérifier que tous les articles sont de nouveau affichés
 
-**Résultat attendu** : le filtrage par tags fonctionne dynamiquement sur la page Blog.
+**Résultat attendu** : le filtrage par tags fonctionne dynamiquement sur la page Blog avec un effet d'animation de redisposition lors du changement de filtre.
 
 ### BLOG-06 [PUBLIC] — Ouverture de l'overlay article depuis la page Blog
 1. Ouvrir `${BASE_URL}/blog`

--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -79,13 +79,14 @@ export default function BlogPage() {
       ) : filtered.length === 0 ? (
         <p className="blog-page__message">Aucun article pour le moment.</p>
       ) : (
-        <div className="blog-masonry">
-          {filtered.map((article) => {
+        <div className="blog-masonry" key={selectedTag ?? '__all__'}>
+          {filtered.map((article, i) => {
             const text = excerpts.get(article.id) ?? '';
             return (
               <button
                 key={article.id}
                 className="blog-card"
+                style={{ animationDelay: `${i * 0.04}s` }}
                 onClick={() => setSelectedArticle(article)}
               >
                 {article.illustration_url && (

--- a/frontend/app/components/NetworkSection.tsx
+++ b/frontend/app/components/NetworkSection.tsx
@@ -61,9 +61,9 @@ export default function NetworkSection() {
         </div>
       )}
 
-      <div className="network-grid">
-        {filtered.map((member) => (
-          <div key={member.id} className="network-card" title={member.name}>
+      <div className="network-grid" key={activeType ?? '__all__'}>
+        {filtered.map((member, i) => (
+          <div key={member.id} className="network-card" title={member.name} style={{ animationDelay: `${i * 0.04}s` }}>
             {member.logo_url ? (
               <img
                 src={member.logo_url}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,3 +1,14 @@
+@keyframes filterCardIn {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
 html, body {
   margin: 0;
   padding: 0;
@@ -396,6 +407,7 @@ body {
   transition: transform 0.3s ease;
   color: #fff;
   font-family: inherit;
+  animation: filterCardIn 0.35s ease both;
 }
 
 .project-card:hover {
@@ -552,6 +564,7 @@ body {
   border-radius: 0.5rem;
   padding: 1rem;
   transition: background 0.2s ease;
+  animation: filterCardIn 0.35s ease both;
 }
 
 .network-card:hover {
@@ -903,6 +916,7 @@ body {
   text-align: left;
   padding: 0;
   transition: transform 0.3s ease, background 0.2s ease;
+  animation: filterCardIn 0.35s ease both;
 }
 
 .blog-card:hover {
@@ -1092,5 +1106,13 @@ body {
   .site-footer__content {
     flex-direction: column;
     text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .project-card,
+  .blog-card,
+  .network-card {
+    animation: none;
   }
 }

--- a/frontend/app/projets/page.tsx
+++ b/frontend/app/projets/page.tsx
@@ -70,11 +70,12 @@ export default function ProjetsPage() {
       ) : filtered.length === 0 ? (
         <p className="projets-page__message">Aucun projet pour le moment.</p>
       ) : (
-        <div className="projets-grid">
-          {filtered.map((project) => (
+        <div className="projets-grid" key={selectedTag ?? '__all__'}>
+          {filtered.map((project, i) => (
             <button
               key={project.id}
               className={`project-card${!project.thumbnail_url ? ' project-card--no-thumbnail' : ''}`}
+              style={{ animationDelay: `${i * 0.04}s` }}
               onClick={() => setSelectedProject(project)}
             >
               {project.thumbnail_url && (


### PR DESCRIPTION
## Description

Closes #90

Ajout d'un effet d'animation de redisposition (fade-in + scale avec stagger) sur les cartes lors du filtrage par tags sur les pages Projets, Blog et la section Réseau.

---

## Documentation

### Implémentation

**CSS** (`frontend/app/globals.css`) :
- Animation `@keyframes filterCardIn` (350ms ease, opacity 0→1 + scale 0.92→1)
- Appliquée à `.project-card`, `.blog-card`, `.network-card`
- Support `prefers-reduced-motion: reduce`

**React** (3 composants) :
- `key={selectedTag|activeType}` sur les conteneurs de grille → force le re-mount au changement de filtre
- `animationDelay` progressif (40ms/carte) → effet de cascade

### Choix techniques
- CSS pur, aucune dépendance ajoutée
- Approche `key` React pour déclencher l'animation à chaque changement de filtre

### Tests
- TypeScript compile sans erreur
- Tests browser mis à jour : PROJ-02, BLOG-05, NET-02