### PR TITLE
claude/debug-browser-tests-dGFpf

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -63,8 +63,10 @@ jobs:
             set -e
             cd ~/n8n-traefik/repos/culturall-website
             git fetch origin "$BRANCH"
-            git checkout -B "$BRANCH" "origin/$BRANCH"
-            git reset --hard "origin/$BRANCH"
+            # Detached HEAD pour éviter le conflit si la branche est déjà
+            # checkée dans un worktree (ex: /workspace/culturall-website-issue-N
+            # créé par le ticket-workflow).
+            git checkout --detach "origin/$BRANCH"
             ./scripts/tnr-docker.sh up
             # Le compose project ajoute le suffixe -tnr (cf. tnr-docker.sh)
             docker network connect culturall-website-tnr_default claude-worker || true


### PR DESCRIPTION
Le step 'Build env from branch' échouait avec :
  fatal: 'feat/issue-N-...' is already used by worktree at
  '/workspace/culturall-website-issue-N'

Cause : le ticket-workflow crée un worktree par issue dans
/workspace/culturall-website-issue-N qui share la même base git que le
clone principal ~/n8n-traefik/repos/culturall-website. git refuse alors
de checkouter la branche déjà locked par le worktree.

Fix : passer en detached HEAD sur origin/\$BRANCH — même contenu pour le
build TNR, sans toucher aux refs de branches.