### PR TITLE
Add URL-based project selection and deep linking support

### DIFF
--- a/frontend/app/components/ProjectsSection.tsx
+++ b/frontend/app/components/ProjectsSection.tsx
@@ -43,7 +43,7 @@ export default function ProjectsSection() {
         {projects.map((project) => (
           <Link
             key={project.id}
-            href="/projets"
+            href={`/projets?project=${project.id}`}
             className={`projects-section__card${!project.thumbnail_url ? ' projects-section__card--no-thumbnail' : ''}`}
           >
             {project.thumbnail_url && (

--- a/frontend/app/projets/page.tsx
+++ b/frontend/app/projets/page.tsx
@@ -10,7 +10,16 @@ export default function ProjetsPage() {
   const [loading, setLoading] = useState(true);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-  const clearSelection = useCallback(() => setSelectedProject(null), []);
+  const clearSelection = useCallback(() => {
+    setSelectedProject(null);
+    if (typeof window !== 'undefined') {
+      const url = new URL(window.location.href);
+      if (url.searchParams.has('project')) {
+        url.searchParams.delete('project');
+        window.history.replaceState({}, '', url.pathname + url.search);
+      }
+    }
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -23,7 +32,14 @@ export default function ProjetsPage() {
         return res.json();
       })
       .then((data) => {
-        if (Array.isArray(data)) setProjects(data);
+        if (Array.isArray(data)) {
+          setProjects(data);
+          const requestedId = new URLSearchParams(window.location.search).get('project');
+          if (requestedId) {
+            const match = data.find((p: Project) => String(p.id) === requestedId);
+            if (match) setSelectedProject(match);
+          }
+        }
       })
       .catch((err) => {
         if (err.name !== 'AbortError') setProjects([]);


### PR DESCRIPTION
## Summary
This PR implements URL-based project selection, allowing users to deep link directly to a specific project via query parameters and maintaining that state in the browser history.

## Key Changes
- **ProjectsSection.tsx**: Updated project card links to include the project ID as a query parameter (`?project={id}`) instead of linking to a plain `/projets` route
- **projets/page.tsx**: 
  - Enhanced `clearSelection` callback to remove the `project` query parameter from the URL when clearing the selection
  - Added logic to the data fetch handler to automatically select a project if a `project` query parameter is present in the URL and matches a loaded project
  - Added server-side rendering safety check (`typeof window !== 'undefined'`) when manipulating browser history

## Implementation Details
- When a project card is clicked, the URL updates to include the project ID as a query parameter
- On page load or data refresh, if a `project` query parameter exists, the component automatically selects and displays that project
- Clearing the selection removes the query parameter while maintaining the page path
- Uses `window.history.replaceState()` to update the URL without creating new history entries

https://claude.ai/code/session_01FsLFBpYD5ZECEJoDVJJRCT