### PR TITLE
Replace login form with Site en construction page

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -221,50 +221,39 @@ body {
   cursor: not-allowed;
 }
 
-/* Login page */
-.login-page {
+/* Under construction page */
+.under-construction-page {
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   min-height: 100vh;
   padding: 2rem;
-  background: #111;
-}
-
-.login-card {
-  width: 100%;
-  max-width: 400px;
-}
-
-.login-title {
-  font-size: 2rem;
-  font-weight: 700;
-  margin: 0 0 0.5rem;
-}
-
-.login-subtitle {
-  font-size: 1rem;
-  opacity: 0.7;
-  margin: 0 0 2rem;
-}
-
-.login-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1.25rem;
-}
-
-.login-submit {
-  width: 100%;
+  background: #000;
+  gap: 2rem;
   text-align: center;
 }
 
-.login-error {
-  padding: 0.75rem 1rem;
-  background: #7f1d1d;
-  border-radius: 6px;
-  font-size: 0.95rem;
-  margin: 0 0 1rem;
+.under-construction-logo {
+  width: auto;
+  height: auto;
+  max-width: min(300px, 80vw);
+  max-height: 120px;
+  object-fit: contain;
+}
+
+.under-construction-fallback {
+  font-size: clamp(2rem, 8vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #fff;
+}
+
+.under-construction-title {
+  font-size: clamp(1.5rem, 5vw, 2.25rem);
+  font-weight: 600;
+  margin: 0;
+  color: #fff;
 }
 
 /* Homepage projects section */

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,101 +1,35 @@
 'use client';
 
-import { Suspense, useState, FormEvent } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
-function LoginForm() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-  const [submitting, setSubmitting] = useState(false);
-
-  async function handleSubmit(e: FormEvent) {
-    e.preventDefault();
-    setError('');
-    setSubmitting(true);
-
-    try {
-      const res = await fetch(`${API_URL}/api/auth/login/`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ username, password }),
-      });
-
-      if (res.ok) {
-        const next = searchParams.get('next') || '/';
-        router.push(next);
-        router.refresh();
-      } else {
-        const body = await res.json();
-        setError(body.error || 'Erreur de connexion.');
-      }
-    } catch {
-      setError('Une erreur est survenue. Veuillez réessayer.');
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
-  return (
-    <>
-      {error && <p className="login-error">{error}</p>}
-
-      <form className="login-form" onSubmit={handleSubmit} noValidate>
-        <div className="contact-field">
-          <label htmlFor="username">Nom d&apos;utilisateur</label>
-          <input
-            id="username"
-            name="username"
-            type="text"
-            autoComplete="username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
-          />
-        </div>
-
-        <div className="contact-field">
-          <label htmlFor="password">Mot de passe</label>
-          <input
-            id="password"
-            name="password"
-            type="password"
-            autoComplete="current-password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </div>
-
-        <button
-          type="submit"
-          className="contact-submit login-submit"
-          disabled={submitting}
-        >
-          {submitting ? 'Connexion en cours…' : 'Se connecter'}
-        </button>
-      </form>
-    </>
-  );
-}
-
 export default function LoginPage() {
+  const [logoUrl, setLogoUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/auth/check/`, { credentials: 'include' })
+      .then((res) => res.json())
+      .then((data) => setLogoUrl(data.logo_url ?? null))
+      .catch(() => setLogoUrl(null));
+  }, []);
+
   return (
-    <main className="login-page">
-      <div className="login-card">
-        <h1 className="login-title">Connexion</h1>
-        <p className="login-subtitle">
-          Veuillez vous connecter pour accéder au site.
-        </p>
-        <Suspense>
-          <LoginForm />
-        </Suspense>
-      </div>
+    <main className="under-construction-page">
+      {logoUrl ? (
+        <Image
+          src={logoUrl}
+          alt="Cultur'all"
+          width={300}
+          height={80}
+          className="under-construction-logo"
+          priority
+        />
+      ) : (
+        <span className="under-construction-fallback">Cultur&apos;all</span>
+      )}
+      <h1 className="under-construction-title">Site en construction</h1>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
Remplace le formulaire de login par une page "Site en construction" minimaliste, conformément à #103.

- `frontend/app/login/page.tsx` : page client qui récupère le `logo_url` via `/api/auth/check/` et affiche le logo centré (fallback texte "Cultur'all") avec le titre "Site en construction" en dessous. Plus aucun formulaire visible.
- `frontend/app/globals.css` : suppression des styles du formulaire de login (`.login-card`, `.login-title`, `.login-subtitle`, `.login-form`, `.login-submit`, `.login-error`) et ajout des styles `.under-construction-*` (fond noir plein écran, flex column centré, logo et titre responsive via `clamp()`).
- Middleware inchangé : les anonymes sont toujours redirigés vers `/login`, les admins authentifiés via `/admin/` Django continuent à passer normalement.

## Test plan
- [ ] Visiter `/` en non-authentifié → redirection vers `/login` qui affiche fond noir, logo centré, titre "Site en construction".
- [ ] Si aucun logo n'est uploadé côté admin, le fallback texte "Cultur'all" s'affiche à la place.
- [ ] Se connecter via `/admin/` puis visiter `/` → accès normal au site (pas de redirection vers `/login`).
- [ ] Une fois loggé en admin, naviguer sur les pages publiques (`/projets`, `/blog`, `/a-propos`, `/contact`) → tout reste accessible.
- [ ] Vérifier le rendu responsive (mobile + desktop) : logo et titre lisibles, pas de débordement.

Fixes #103

---
_Generated by [Claude Code](https://claude.ai/code/session_01YKn71dbK8cjL1QkvAtLGM9)_