### PR TITLE
Add support for alternative domain cultur-all.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,10 +4,11 @@
 # ─── Django / Wagtail ──────────────────────────────────────────
 DJANGO_SECRET_KEY=change-me-in-production
 DEBUG=True
+# Prod : culturall-website.nickorp.com,cultur-all.org
 ALLOWED_HOSTS=localhost,127.0.0.1
 # Requis en prod pour que les POST admin passent le check CSRF derrière un
 # reverse proxy HTTPS. Liste d'origines (schéma inclus), séparées par des virgules.
-# Prod : https://culturall-website.nickorp.com
+# Prod : https://culturall-website.nickorp.com,https://cultur-all.org
 CSRF_TRUSTED_ORIGINS=
 # ⚠️ DATABASE_URL doit contenir le MÊME password que POSTGRES_PASSWORD ci-dessous.
 # Si tu changes l'un, change l'autre. Caractères spéciaux dans le password :

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,6 +15,8 @@
 #       https://culturall-website.nickorp.com/api     → django  (DRF API)
 #       https://culturall-website.nickorp.com/static  → django  (servi via whitenoise)
 #       https://culturall-website.nickorp.com/        → nextjs  (catch-all front)
+#       https://cultur-all.org/{admin,api,static}     → django  (domaine alternatif)
+#       https://cultur-all.org/                       → nextjs  (domaine alternatif)
 #       https://media.culturall-website.nickorp.com/  → minio   (médias S3-compatible)
 #
 # Placeholders à remplacer :
@@ -53,7 +55,7 @@ services:
       - "traefik.docker.network=n8n-traefik_default"
 
       # Routeur backend — admin/api/static (Django + Wagtail + whitenoise)
-      - "traefik.http.routers.culturall-website-back.rule=Host(`culturall-website.nickorp.com`) && (PathPrefix(`/admin`) || PathPrefix(`/api`) || PathPrefix(`/static`))"
+      - "traefik.http.routers.culturall-website-back.rule=(Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)) && (PathPrefix(`/admin`) || PathPrefix(`/api`) || PathPrefix(`/static`))"
       - "traefik.http.routers.culturall-website-back.entrypoints=websecure"
       - "traefik.http.routers.culturall-website-back.tls=true"
       - "traefik.http.routers.culturall-website-back.tls.certresolver=myresolver"
@@ -61,7 +63,7 @@ services:
       - "traefik.http.services.culturall-website-back.loadbalancer.server.port=8000"
 
       # Redirect HTTP → HTTPS pour le backend
-      - "traefik.http.routers.culturall-website-back-http.rule=Host(`culturall-website.nickorp.com`) && (PathPrefix(`/admin`) || PathPrefix(`/api`) || PathPrefix(`/static`))"
+      - "traefik.http.routers.culturall-website-back-http.rule=(Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)) && (PathPrefix(`/admin`) || PathPrefix(`/api`) || PathPrefix(`/static`))"
       - "traefik.http.routers.culturall-website-back-http.entrypoints=web"
       - "traefik.http.routers.culturall-website-back-http.middlewares=culturall-website-redirect-to-https"
     restart: always
@@ -84,7 +86,7 @@ services:
       - "traefik.docker.network=n8n-traefik_default"
 
       # Routeur frontend — catch-all (priorité plus basse que /admin /api /static)
-      - "traefik.http.routers.culturall-website-front.rule=Host(`culturall-website.nickorp.com`)"
+      - "traefik.http.routers.culturall-website-front.rule=Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)"
       - "traefik.http.routers.culturall-website-front.entrypoints=websecure"
       - "traefik.http.routers.culturall-website-front.tls=true"
       - "traefik.http.routers.culturall-website-front.tls.certresolver=myresolver"
@@ -92,7 +94,7 @@ services:
       - "traefik.http.services.culturall-website-front.loadbalancer.server.port=3000"
 
       # Redirect HTTP → HTTPS pour le frontend
-      - "traefik.http.routers.culturall-website-front-http.rule=Host(`culturall-website.nickorp.com`)"
+      - "traefik.http.routers.culturall-website-front-http.rule=Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)"
       - "traefik.http.routers.culturall-website-front-http.entrypoints=web"
       - "traefik.http.routers.culturall-website-front-http.middlewares=culturall-website-redirect-to-https"
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -16,6 +16,14 @@ const nextConfig = {
         protocol: 'https',
         hostname: '*.nickorp.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'cultur-all.org',
+      },
+      {
+        protocol: 'https',
+        hostname: '*.cultur-all.org',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
This PR adds support for an alternative domain `cultur-all.org` alongside the existing `culturall-website.nickorp.com` domain. The application now routes traffic from both domains to the appropriate backend (Django) and frontend (Next.js) services.

## Key Changes
- **Docker Compose Configuration**: Updated Traefik routing rules to accept both `culturall-website.nickorp.com` and `cultur-all.org` for both backend and frontend services
  - Backend router now matches both domains for `/admin`, `/api`, and `/static` paths
  - Frontend router now matches both domains as catch-all routes
  - HTTP to HTTPS redirects updated for both domains

- **Next.js Image Configuration**: Added image hostname allowlist entries for the new domain
  - Added `cultur-all.org` for exact domain matching
  - Added `*.cultur-all.org` for wildcard subdomain support

- **Environment Configuration**: Updated `.env.example` documentation
  - Added production example for `ALLOWED_HOSTS` including both domains
  - Updated `CSRF_TRUSTED_ORIGINS` production example to include the new domain with HTTPS scheme

## Implementation Details
The routing configuration maintains proper priority levels (backend priority 100, frontend priority 10) to ensure `/admin`, `/api`, and `/static` paths are correctly routed to Django before falling back to the Next.js frontend for other routes.

https://claude.ai/code/session_01BLc7eW42MdGsDqFcnQyiMW