### PR TITLE
fix(prod): 301-redirect www.cultur-all.org → cultur-all.org

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -17,6 +17,7 @@
 #       https://culturall-website.nickorp.com/        → nextjs  (catch-all front)
 #       https://cultur-all.org/{admin,api,static}     → django  (domaine alternatif)
 #       https://cultur-all.org/                       → nextjs  (domaine alternatif)
+#       https://www.cultur-all.org/*                  → 301 redirect vers https://cultur-all.org/*
 #       https://media.culturall-website.nickorp.com/  → minio   (médias S3-compatible)
 #
 # Placeholders à remplacer :
@@ -101,6 +102,28 @@ services:
       # Middleware partagé : redirect to https
       - "traefik.http.middlewares.culturall-website-redirect-to-https.redirectscheme.scheme=https"
       - "traefik.http.middlewares.culturall-website-redirect-to-https.redirectscheme.permanent=true"
+
+      # Redirect 301 www.cultur-all.org → cultur-all.org (apex), HTTP comme HTTPS,
+      # en un seul saut. Permet aussi à Let's Encrypt d'émettre un cert couvrant
+      # le SAN www.cultur-all.org via les routeurs ci-dessous.
+      - "traefik.http.middlewares.culturall-website-www-to-apex.redirectregex.regex=^https?://www\\.cultur-all\\.org/(.*)"
+      - "traefik.http.middlewares.culturall-website-www-to-apex.redirectregex.replacement=https://cultur-all.org/$${1}"
+      - "traefik.http.middlewares.culturall-website-www-to-apex.redirectregex.permanent=true"
+
+      # Routeur HTTPS pour www — déclenche l'émission du cert Let's Encrypt
+      # (SAN www.cultur-all.org) puis redirige vers l'apex.
+      - "traefik.http.routers.culturall-website-www.rule=Host(`www.cultur-all.org`)"
+      - "traefik.http.routers.culturall-website-www.entrypoints=websecure"
+      - "traefik.http.routers.culturall-website-www.tls=true"
+      - "traefik.http.routers.culturall-website-www.tls.certresolver=myresolver"
+      - "traefik.http.routers.culturall-website-www.middlewares=culturall-website-www-to-apex"
+      - "traefik.http.routers.culturall-website-www.service=culturall-website-front"
+
+      # Routeur HTTP pour www — redirige directement vers https://cultur-all.org/
+      - "traefik.http.routers.culturall-website-www-http.rule=Host(`www.cultur-all.org`)"
+      - "traefik.http.routers.culturall-website-www-http.entrypoints=web"
+      - "traefik.http.routers.culturall-website-www-http.middlewares=culturall-website-www-to-apex"
+      - "traefik.http.routers.culturall-website-www-http.service=culturall-website-front"
     restart: always
 
   minio:


### PR DESCRIPTION
## Summary
- Ajoute deux routeurs Traefik (`web` + `websecure`) pour `www.cultur-all.org` et un middleware `redirectregex` qui renvoie 301 vers l'apex `cultur-all.org` en un seul saut (HTTP comme HTTPS).
- Déclenche au passage l'émission par Let's Encrypt d'un cert couvrant le SAN `www.cultur-all.org` (le cert actuel n'a que `cultur-all.org` + `culturall-website.nickorp.com`, ce qui faisait échouer le TLS sur `www`).

## Contexte
Suite au repointage DNS de `cultur-all.org` (depuis l'ancien WordPress OVH vers le VPS prod), `https://www.cultur-all.org` cassait en TLS faute de cert pour le sous-domaine — donnant l'impression que les visiteurs étaient renvoyés sur l'ancien site (souvent à cause d'un cache DNS local pointant encore sur l'ancienne IP `92.222.139.156`).

`ALLOWED_HOSTS` Django n'a pas besoin d'être étendu : la redirection se fait au niveau Traefik avant que la requête n'atteigne l'app.

## Test plan
- [ ] Redéployer la stack prod (`docker compose ... up -d`) — pas de rebuild d'image nécessaire, ce sont uniquement des labels Traefik.
- [ ] Vérifier la redirection HTTPS : `curl -sI https://www.cultur-all.org` → `301` vers `https://cultur-all.org/`.
- [ ] Vérifier la redirection HTTP : `curl -sI http://www.cultur-all.org` → `301` vers `https://cultur-all.org/`.
- [ ] Vérifier l'élargissement du cert : `echo | openssl s_client -servername www.cultur-all.org -connect cultur-all.org:443 2>/dev/null | openssl x509 -noout -text | grep DNS` → doit lister `www.cultur-all.org`.
- [ ] Vérifier que l'apex n'est pas affecté : `curl -sI https://cultur-all.org` → `307` vers `/login` (comportement actuel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)