### PR TITLE
fix(prod): point MinIO router to media.cultur-all.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,7 @@ MINIO_ENDPOINT_URL=http://minio:9000
 MINIO_BUCKET_NAME=media
 # Endpoint PUBLIC (URLs des médias servies au navigateur via Traefik)
 # Dev    : http://localhost:9000
-# Prod   : https://media.culturall-website.nickorp.com
+# Prod   : https://media.cultur-all.org
 MINIO_PUBLIC_URL=http://localhost:9000
 
 # ─── Next.js ───────────────────────────────────────────────────

--- a/.env.test
+++ b/.env.test
@@ -20,7 +20,7 @@ MINIO_ENDPOINT_URL=http://minio:9000
 MINIO_BUCKET_NAME=media
 # Endpoint PUBLIC (URLs des médias servies au navigateur via Traefik)
 # Dev    : http://localhost:9000
-# Prod   : https://media.culturall-website.nickorp.com
+# Prod   : https://media.cultur-all.org
 MINIO_PUBLIC_URL=http://localhost:9000
 
 # ─── Next.js ───────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ La production utilise des images Docker pré-buildées, poussées sur GHCR par l
 - Le réseau Docker externe `traefik_default` créé (`docker network create traefik_default`)
 - Les enregistrements DNS pointant vers le VPS :
   - `culturall-website.nickorp.com` (site)
-  - `media.culturall-website.nickorp.com` (médias MinIO)
+  - `media.cultur-all.org` (médias MinIO)
 
 ### 1. Cloner le dépôt sur le VPS
 
@@ -109,7 +109,7 @@ DEBUG=False
 ALLOWED_HOSTS=culturall-website.nickorp.com
 CSRF_TRUSTED_ORIGINS=https://culturall-website.nickorp.com
 MINIO_ROOT_PASSWORD=<mot de passe fort>
-MINIO_PUBLIC_URL=https://media.culturall-website.nickorp.com
+MINIO_PUBLIC_URL=https://media.cultur-all.org
 NEXT_PUBLIC_API_URL=https://culturall-website.nickorp.com
 NODE_ENV=production
 REGISTRY=ghcr.io/nicolasdeclerck/culturall-website

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,11 +18,11 @@
 #       https://cultur-all.org/{admin,api,static}     → django  (domaine alternatif)
 #       https://cultur-all.org/                       → nextjs  (domaine alternatif)
 #       https://www.cultur-all.org/*                  → 301 redirect vers https://cultur-all.org/*
-#       https://media.culturall-website.nickorp.com/  → minio   (médias S3-compatible)
+#       https://media.cultur-all.org/                 → minio   (médias S3-compatible)
 #
 # Placeholders à remplacer :
 #   culturall-website.nickorp.com            : domaine principal de l'app (ex: studio.example.com)
-#   media.culturall-website.nickorp.com      : sous-domaine des médias    (ex: media.studio.example.com)
+#   media.cultur-all.org                     : sous-domaine des médias    (ex: media.studio.example.com)
 #   n8n-traefik_default   : nom du network Traefik externe (ex: n8n-traefik_default)
 #   culturall-website   : nom du projet docker compose (ex: studio-site)
 #   myresolver     : nom du resolver Let's Encrypt côté Traefik (ex: myresolver)
@@ -135,17 +135,17 @@ services:
       - "traefik.docker.network=n8n-traefik_default"
 
       # MinIO sur sous-domaine dédié — préfixe = bucket name
-      # URL publique : https://media.culturall-website.nickorp.com/<bucket>/<key>
+      # URL publique : https://media.cultur-all.org/<bucket>/<key>
       # où <bucket> = valeur de MINIO_BUCKET_NAME dans .env.prod.
       # (compatible avec une migration future vers Cloudflare R2 sur le
       #  même sous-domaine)
-      - "traefik.http.routers.culturall-website-media.rule=Host(`media.culturall-website.nickorp.com`)"
+      - "traefik.http.routers.culturall-website-media.rule=Host(`media.cultur-all.org`)"
       - "traefik.http.routers.culturall-website-media.entrypoints=websecure"
       - "traefik.http.routers.culturall-website-media.tls=true"
       - "traefik.http.routers.culturall-website-media.tls.certresolver=myresolver"
       - "traefik.http.services.culturall-website-media.loadbalancer.server.port=9000"
 
-      - "traefik.http.routers.culturall-website-media-http.rule=Host(`media.culturall-website.nickorp.com`)"
+      - "traefik.http.routers.culturall-website-media-http.rule=Host(`media.cultur-all.org`)"
       - "traefik.http.routers.culturall-website-media-http.entrypoints=web"
       - "traefik.http.routers.culturall-website-media-http.middlewares=culturall-website-redirect-to-https"
     volumes:

--- a/docs/github-actions-setup.md
+++ b/docs/github-actions-setup.md
@@ -11,7 +11,7 @@
   attaché à un network Docker externe partagé (par défaut `traefik_default`).
   Les services `django`, `nextjs` et `minio` s'enregistrent auprès de Traefik
   via des labels — pas de nginx ni de certbot dans le compose de prod.
-- **DNS** : `culturall-website.nickorp.com` et `media.culturall-website.nickorp.com` doivent pointer vers l'IP du VPS
+- **DNS** : `culturall-website.nickorp.com`, `cultur-all.org`, `www.cultur-all.org` et `media.cultur-all.org` doivent pointer vers l'IP du VPS
   (records A ou AAAA) avant le premier déploiement, pour que Let's Encrypt
   puisse émettre les certificats.
 - **Clone du repo sur le VPS** : le dépôt doit être cloné à `~/n8n-traefik/repos/culturall-website`


### PR DESCRIPTION
## Summary
- Met les routeurs Traefik MinIO (websecure + web) sur `Host(\`media.cultur-all.org\`)` au lieu de l'ancien `media.culturall-website.nickorp.com`. Aligne aussi le header doc + placeholders du compose, et les références dans `README.md`, `.env.example`, `.env.test`, `docs/github-actions-setup.md`.
- **Pourquoi** : `MINIO_PUBLIC_URL` dans `.env.prod` (serveur) pointe déjà sur `media.cultur-all.org` — donc Wagtail/DRF publient des URLs sur ce hostname, mais aucun routeur Traefik ne répond dessus → 404 sur toutes les images. Le diff local non committé sur le VPS bloquait par ailleurs le pipeline de déploiement.

## Pré-requis vérifiés
- ✅ DNS : `media.cultur-all.org → 54.36.103.209` (même IP que l'apex `cultur-all.org`), donc le challenge HTTP-01 de Let's Encrypt passera dès que le routeur monte.
- ✅ `frontend/next.config.js` : `*.cultur-all.org` est déjà dans `images.remotePatterns` — `next/image` continuera à optimiser les médias.
- ✅ `.env.prod` (serveur, non-tracked) a déjà `MINIO_PUBLIC_URL=https://media.cultur-all.org`, donc runtime et Traefik s'alignent.

## Impact à connaître
- Les anciens liens `https://media.culturall-website.nickorp.com/...` (s'ils existent en cache externe ou pages indexées) ne répondront plus. Aucun routeur de fallback n'est ajouté ici — à voir si on veut un 301 ultérieurement.
- Premier hit sur `https://media.cultur-all.org/` après deploy déclenche l'émission du cert Let's Encrypt (latence supplémentaire le temps du challenge).

## Test plan
- [ ] CI verte
- [ ] Après merge + deploy : `curl -I https://media.cultur-all.org/<bucket>/<key>` répond 200 (ou 403/404 selon ACL, mais pas Traefik 404)
- [ ] `openssl s_client -servername media.cultur-all.org -connect media.cultur-all.org:443` montre un cert Let's Encrypt valide pour ce SAN
- [ ] Une page Wagtail avec image se charge correctement depuis `https://cultur-all.org/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)