### PR TITLE
feat: self-host homepage hero video with admin upload

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -12,6 +12,7 @@ from home.auth_views import auth_check, auth_login, auth_logout
 from home.views import contact_submit
 from network.views import network_member_list
 from projects.views import project_featured, project_list
+from site_settings.views import site_settings
 
 
 def hello(request):
@@ -45,6 +46,7 @@ urlpatterns = [
     path("api/projects/", project_list, name="project-list"),
     path("api/projects/featured/", project_featured, name="project-featured"),
     path("api/blog/articles/", article_list, name="article-list"),
+    path("api/site/settings/", site_settings, name="site-settings"),
 
     # Catch-all Wagtail (page tree) — désactivé tant que la racine est `hello`.
     # Décommente quand un HomePage existe et retire la route `hello` ci-dessus.

--- a/backend/site_settings/migrations/0003_sitesettings_background_video_and_more.py
+++ b/backend/site_settings/migrations/0003_sitesettings_background_video_and_more.py
@@ -1,0 +1,47 @@
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("wagtailimages", "0026_delete_uploadedimage"),
+        ("site_settings", "0002_sitesettings_logo"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="sitesettings",
+            name="background_video",
+            field=models.FileField(
+                blank=True,
+                help_text=(
+                    "Vidéo lue en boucle, muette, en fond de la page d'accueil. "
+                    "Format source recommandé : MP4 H.264, durée 10-30s, max "
+                    "50 Mo. La vidéo est automatiquement transcompressée à "
+                    "l'upload (H.264, max 1080p, sans audio) — la sauvegarde "
+                    "peut prendre plusieurs secondes."
+                ),
+                null=True,
+                upload_to="hero/",
+                verbose_name="Vidéo de fond (page d'accueil)",
+            ),
+        ),
+        migrations.AddField(
+            model_name="sitesettings",
+            name="background_video_poster",
+            field=models.ForeignKey(
+                blank=True,
+                help_text=(
+                    "Image affichée pendant le chargement de la vidéo de fond. "
+                    "Optionnel : si vide, la première image de la vidéo est "
+                    "utilisée."
+                ),
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name="+",
+                to="wagtailimages.image",
+                verbose_name="Image de poster vidéo",
+            ),
+        ),
+    ]

--- a/backend/site_settings/models.py
+++ b/backend/site_settings/models.py
@@ -1,7 +1,18 @@
+import logging
+import os
+import subprocess
+import tempfile
+
+from django.core.exceptions import ValidationError
+from django.core.files.base import ContentFile
 from django.db import models
 from wagtail.admin.panels import FieldPanel
 from wagtail.contrib.settings.models import BaseSiteSetting, register_setting
 from wagtail.images import get_image_model_string
+
+logger = logging.getLogger(__name__)
+
+FFMPEG_TIMEOUT_SECONDS = 600
 
 
 @register_setting
@@ -28,11 +39,129 @@ class SiteSettings(BaseSiteSetting):
         ),
     )
 
+    background_video = models.FileField(
+        upload_to="hero/",
+        null=True,
+        blank=True,
+        verbose_name="Vidéo de fond (page d'accueil)",
+        help_text=(
+            "Vidéo lue en boucle, muette, en fond de la page d'accueil. "
+            "Format source recommandé : MP4 H.264, durée 10-30s, max 50 Mo. "
+            "La vidéo est automatiquement transcompressée à l'upload "
+            "(H.264, max 1080p, sans audio) — la sauvegarde peut prendre "
+            "plusieurs secondes."
+        ),
+    )
+
+    background_video_poster = models.ForeignKey(
+        get_image_model_string(),
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+",
+        verbose_name="Image de poster vidéo",
+        help_text=(
+            "Image affichée pendant le chargement de la vidéo de fond. "
+            "Optionnel : si vide, la première image de la vidéo est utilisée."
+        ),
+    )
+
     panels = [
         FieldPanel("logo"),
+        FieldPanel("background_video"),
+        FieldPanel("background_video_poster"),
         FieldPanel("require_authentication"),
     ]
 
     class Meta:
         verbose_name = "Paramètres du site"
         verbose_name_plural = "Paramètres du site"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._initial_video_name = (
+            self.background_video.name if self.background_video else None
+        )
+
+    def save(self, *args, **kwargs):
+        current_name = self.background_video.name if self.background_video else None
+        if current_name and current_name != self._initial_video_name:
+            self._transcode_background_video()
+        super().save(*args, **kwargs)
+        self._initial_video_name = (
+            self.background_video.name if self.background_video else None
+        )
+
+    def _transcode_background_video(self):
+        """Replace `background_video` with an H.264 / 1080p / no-audio version.
+
+        Runs ffmpeg synchronously on the freshly uploaded file before it is
+        committed to storage, then swaps the field's content with the
+        transcoded output. Raises ValidationError on failure so the admin
+        sees an explicit error message.
+        """
+        with tempfile.NamedTemporaryFile(suffix=".src", delete=False) as src_file:
+            for chunk in self.background_video.chunks():
+                src_file.write(chunk)
+            src_path = src_file.name
+        dst_path = src_path + ".out.mp4"
+
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i", src_path,
+                    "-vf",
+                    "scale='min(1920,iw)':'min(1080,ih)':"
+                    "force_original_aspect_ratio=decrease",
+                    "-c:v", "libx264",
+                    "-preset", "medium",
+                    "-crf", "23",
+                    "-pix_fmt", "yuv420p",
+                    "-an",
+                    "-movflags", "+faststart",
+                    dst_path,
+                ],
+                check=True,
+                capture_output=True,
+                timeout=FFMPEG_TIMEOUT_SECONDS,
+            )
+        except FileNotFoundError as exc:
+            self._cleanup_paths(src_path, dst_path)
+            raise ValidationError(
+                "ffmpeg n'est pas installé sur le serveur — "
+                "impossible de transcompresser la vidéo."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            self._cleanup_paths(src_path, dst_path)
+            raise ValidationError(
+                f"La transcompression a dépassé {FFMPEG_TIMEOUT_SECONDS}s. "
+                "Essaie avec une vidéo source plus courte ou plus légère."
+            ) from exc
+        except subprocess.CalledProcessError as exc:
+            self._cleanup_paths(src_path, dst_path)
+            stderr_tail = (exc.stderr or b"").decode("utf-8", errors="replace")[-500:]
+            logger.error("ffmpeg transcode failed: %s", stderr_tail)
+            raise ValidationError(
+                "Échec de la transcompression de la vidéo "
+                "(format source non lisible par ffmpeg)."
+            ) from exc
+
+        original_basename = os.path.basename(self.background_video.name)
+        base, _ = os.path.splitext(original_basename)
+        new_name = f"{base}.h264.mp4"
+        with open(dst_path, "rb") as transcoded:
+            self.background_video.save(
+                new_name, ContentFile(transcoded.read()), save=False
+            )
+
+        self._cleanup_paths(src_path, dst_path)
+
+    @staticmethod
+    def _cleanup_paths(*paths):
+        for path in paths:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass

--- a/backend/site_settings/views.py
+++ b/backend/site_settings/views.py
@@ -1,0 +1,31 @@
+from django.http import JsonResponse
+from django.views.decorators.http import require_GET
+from wagtail.models import Site
+
+from .models import SiteSettings
+
+
+@require_GET
+def site_settings(request):
+    """Return public site settings consumed by the frontend home page."""
+    site = Site.find_for_request(request)
+    settings = SiteSettings.for_site(site)
+
+    background_video_url = None
+    if settings.background_video:
+        background_video_url = request.build_absolute_uri(
+            settings.background_video.url
+        )
+
+    background_video_poster_url = None
+    if settings.background_video_poster:
+        background_video_poster_url = request.build_absolute_uri(
+            settings.background_video_poster.get_rendition("max-1920x1080").url
+        )
+
+    return JsonResponse(
+        {
+            "background_video_url": background_video_url,
+            "background_video_poster_url": background_video_poster_url,
+        }
+    )

--- a/docker/django/Dockerfile
+++ b/docker/django/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         wget \
         git \
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/frontend/app/components/HeroVideo.tsx
+++ b/frontend/app/components/HeroVideo.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+
+interface SiteSettings {
+  background_video_url: string | null;
+  background_video_poster_url: string | null;
+}
+
+export default function HeroVideo() {
+  const [settings, setSettings] = useState<SiteSettings | null>(null);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/site/settings/`, { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data: SiteSettings | null) => setSettings(data))
+      .catch(() => {});
+  }, []);
+
+  if (!settings?.background_video_url) {
+    return null;
+  }
+
+  return (
+    <video
+      autoPlay
+      muted
+      loop
+      playsInline
+      poster={settings.background_video_poster_url ?? undefined}
+      src={settings.background_video_url}
+    />
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -113,15 +113,13 @@ body {
   pointer-events: none;
 }
 
-.landing-video iframe {
+.landing-video video {
   position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 100vw;
-  height: 56.25vw; /* 16:9 ratio */
-  min-height: 100vh;
-  min-width: 177.78vh; /* 16:9 ratio */
-  transform: translate(-50%, -50%);
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   border: none;
 }
 

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,18 +1,13 @@
+import HeroVideo from './components/HeroVideo';
 import NetworkSection from './components/NetworkSection';
 import ProjectsSection from './components/ProjectsSection';
-
-const VIDEO_ID = '0L8953RVKGU';
 
 export default function Home() {
   return (
     <>
       <div className="landing">
         <div className="landing-video">
-          <iframe
-            src={`https://www.youtube.com/embed/${VIDEO_ID}?autoplay=1&mute=1&loop=1&playlist=${VIDEO_ID}&controls=0&rel=0&modestbranding=1&playsinline=1`}
-            allow="autoplay; encrypted-media"
-            title="Vidéo de fond Cultur'all"
-          />
+          <HeroVideo />
         </div>
       </div>
       <ProjectsSection />


### PR DESCRIPTION
## Summary

- Replace the YouTube-embedded iframe on the homepage hero with a self-hosted `<video>` so the admin owns the playback experience and YouTube overlays can no longer leak through.
- Let an admin upload / replace the hero video from the Wagtail "Paramètres du site" panel — no code change required.
- Transcompress the uploaded video automatically (H.264, ≤ 1080p, no audio) to keep the served file lean and the playback consistent across browsers.

Fixes #110

## Changes

### Backend
- `docker/django/Dockerfile`: install `ffmpeg` system-wide (needed for sync transcoding).
- `backend/site_settings/models.py`: extend `SiteSettings` with `background_video` (`FileField`, `upload_to="hero/"`) and `background_video_poster` (FK to `wagtailimages.Image`, optional). Override `save()` to detect a new upload and run `ffmpeg` synchronously (`scale='min(1920,iw)':'min(1080,ih)'`, `libx264`, `crf 23`, `-an`, `+faststart`). Failures raise `ValidationError` with a French message so the admin sees a clear error.
- `backend/site_settings/views.py` *(new)* + `backend/config/urls.py`: expose `GET /api/site/settings/` returning `{ background_video_url, background_video_poster_url }`, following the existing custom-view pattern (no Wagtail API v2 in this repo).
- `backend/site_settings/migrations/0003_…py`: schema migration for the two new fields. Confirmed via `manage.py makemigrations --dry-run` (No changes detected → matches what Django would generate).

### Frontend
- `frontend/app/components/HeroVideo.tsx` *(new)*: client component that fetches `/api/site/settings/` on mount and renders a native `<video autoPlay muted loop playsInline poster={…} src={…} />`. Renders nothing when no video is configured (the `.landing` background colour shows through).
- `frontend/app/page.tsx`: drop the hardcoded `VIDEO_ID = '0L8953RVKGU'` + iframe and mount `<HeroVideo />` instead.
- `frontend/app/globals.css`: replace the YouTube-iframe sizing rules with a single `object-fit: cover` rule on `.landing-video video`.

## How it was tested

- [x] `python manage.py makemigrations --dry-run` (in a throwaway venv) → "No changes detected" (the hand-written migration matches the auto-generated one).
- [x] `python -m py_compile` on every touched backend file.
- [x] `npx tsc --noEmit` clean.
- [ ] Manual verification still TODO once dev stack is running:
  - upload an MP4 from `/admin/settings/site_settings/sitesettings/`, confirm transcoded file is stored on MinIO with `.h264.mp4` suffix
  - confirm homepage plays the transcoded file with no YouTube overlays
  - confirm fallback when `background_video` is empty (no broken UI)

## Risks and rollout

- **Sync ffmpeg in the admin save path** blocks the request for the duration of the transcode. For a 30-second 1080p clip on a modest VPS this is typically a few seconds; very large source files could approach the 600s timeout. The admin sees an explicit French error if it times out or if `ffmpeg` is missing. If this becomes a problem we can move to async (Celery/RQ) — out of scope here.
- **ffmpeg added to the Docker image** increases the backend image size by ~150 MB. Acceptable for a self-hosted VPS; no impact on cold start.
- **Migration is additive** (two nullable fields) — safe to roll forward, safe to roll back.
- **Old hero video file** is not auto-deleted from MinIO when the admin replaces it (Django's default FileField behaviour). Negligible storage leak; can be addressed later if needed.

## Follow-ups

- Auto-extract the first frame as a default poster (would remove the manual poster upload step).
- Move transcoding to a background worker once we have other use cases that justify the infra.
- Reuse this pattern (or `wagtailvideos`) on project pages if/when video content is added there — explicitly deferred per #110 scope.