### PR TITLE
fix(home): drop residual YouTube overlays from background video

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -117,10 +117,10 @@ body {
   position: absolute;
   top: 50%;
   left: 50%;
-  width: 100vw;
-  height: 56.25vw; /* 16:9 ratio */
-  min-height: 100vh;
-  min-width: 177.78vh; /* 16:9 ratio */
+  width: 110vw;
+  height: 61.875vw; /* 16:9 ratio, scaled 110% */
+  min-height: 110vh;
+  min-width: 195.55vh; /* 16:9 ratio, scaled 110% */
   transform: translate(-50%, -50%);
   border: none;
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
       <div className="landing">
         <div className="landing-video">
           <iframe
-            src={`https://www.youtube.com/embed/${VIDEO_ID}?autoplay=1&mute=1&loop=1&playlist=${VIDEO_ID}&controls=0&rel=0&modestbranding=1&playsinline=1`}
+            src={`https://www.youtube-nocookie.com/embed/${VIDEO_ID}?autoplay=1&mute=1&loop=1&playlist=${VIDEO_ID}&controls=0&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3&disablekb=1&fs=0&cc_load_policy=0`}
             allow="autoplay; encrypted-media"
             title="Vidéo de fond Cultur'all"
           />


### PR DESCRIPTION
## Summary

- Durcir l'embed YouTube de la home pour qu'aucun overlay tiers (titre, branding, annotations, suggestions, boutons) ne soit visible — décision produit : on garde l'embed YouTube, pas de self-host.

Fixes #116

## Changes

- `frontend/app/page.tsx` — bascule du domaine sur `youtube-nocookie.com` et ajout des params `iv_load_policy=3` (annotations off), `disablekb=1` (raccourcis clavier off), `fs=0` (bouton plein écran off), `cc_load_policy=0` (sous-titres off).
- `frontend/app/globals.css` — l'iframe est mise à l'échelle 110% (largeur, hauteur et `min-*`) pour que le watermark YouTube et le titre — rendus dans les coins par le player malgré `modestbranding=1` — tombent hors viewport. Le wrapper `.landing` a déjà `overflow: hidden` qui clippe le débordement, et `pointer-events: none` reste en place sur `.landing-video` pour empêcher tout overlay déclenché au survol.

## How it was tested

- [ ] `npm run build` — **non lancé** : le worktree n'a pas de `node_modules` installé. Les changements sont purement textuels (URL d'iframe + valeurs CSS), pas de modification de types ni d'API, donc le risque de casse compile est nul.
- [ ] Vérification manuelle en navigateur (Chrome / Firefox / Safari, desktop + mobile) : à faire après merge sur l'environnement de dev/preprod, en regardant la home pendant le chargement, en survol et au moment du loop.

## Screenshots / recordings

À ajouter après vérification manuelle.

## Risks and rollout

- Le scaling à 110% recadre légèrement la vidéo : ~5% de chaque bord est masqué. Acceptable pour une vidéo de fond ambiante (ID `0L8953RVKGU`), à confirmer visuellement que rien d'important n'est perdu sur les bords.
- `youtube-nocookie.com` est l'embed officiel sans cookies de tracking — comportement de lecture identique à `youtube.com`.

## Follow-ups

- Si des résidus subsistent (par ex. flash du bouton play au tout début, ou overlay au moment du loop), itérer en passant à l'IFrame Player API pour piloter `seekTo(0) + playVideo()` au lieu de `loop=1`.
- Issue #110 (self-host + upload admin) à fermer séparément — stratégie abandonnée.

---

Closes #116