### PR TITLE
fix(blog): unblock prod deploy — illustration FK in data migration

### DIFF
--- a/backend/blog/migrations/0003_migrate_articles_to_pages.py
+++ b/backend/blog/migrations/0003_migrate_articles_to_pages.py
@@ -58,7 +58,12 @@ def migrate_articles_to_pages(apps, schema_editor):
             slug=slug,
             summary=article.summary,
             content=article.content,
-            illustration=article.illustration,
+            # On passe l'ID, pas l'instance : `article.illustration` est une
+            # instance du modèle historique de wagtailimages.Image (récupéré
+            # via apps.get_model), incompatible avec le FK de ArticlePage qui
+            # attend le modèle runtime. Même table en base, classes Python
+            # distinctes.
+            illustration_id=article.illustration_id,
             live=article.live,
             has_unpublished_changes=article.has_unpublished_changes,
             first_published_at=article.first_published_at or article.created_at,


### PR DESCRIPTION
## Context

#122 (which closed #118) merged successfully but the **production deploy failed** during migration:

\`\`\`
ValueError: Cannot assign \"<Image: Image object (106)>\":
\"ArticlePage.illustration\" must be a \"Image\" instance.
  Applying blog.0003_migrate_articles_to_pages...
\`\`\`

## Root cause

The data migration loads `Article` rows via `apps.get_model(\"blog\", \"Article\")` (historical model), so `article.illustration` returns an instance of the **historical** `wagtailimages.Image` class. The line

\`\`\`python
illustration=article.illustration,
\`\`\`

then tries to assign it to `ArticlePage.illustration` whose FK descriptor was built against the **runtime** `Image` class. Same database row, but two different Python classes from Django's model registry — assignment rejected.

The bug was invisible on local testing because the dev DB had no pre-existing Articles, so the loop body never ran.

## Fix

Assign by PK rather than by instance:

\`\`\`python
illustration_id=article.illustration_id,
\`\`\`

This sidesteps the type check entirely — the FK is set directly via its `_id` attribute. Same column, no instance comparison.

## Out of scope (worth a follow-up)

The `test_migration.py` file added in #122 only verifies post-migration state. A proper test using `MigrationExecutor` to roll back, create historical Articles with illustrations, replay the migration, and assert ArticlePage.illustration is correctly populated would have caught this. Worth adding in a small follow-up ticket if we want a regression net.

## Test plan

- [ ] Re-run the prod deploy — `python manage.py migrate` should succeed.
- [ ] After migration: every published Article now has an `ArticlePage` with `illustration_id` matching the original Article's image.
- [ ] Visit \`/blog\` on prod frontend — articles render with their illustrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)