### PR TITLE
feat(projects): migrate Snippet Project to native Wagtail Pages (#119)

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -12,7 +12,7 @@ from home.auth_views import auth_check, auth_login, auth_logout
 from home.views import contact_submit
 from network.views import network_member_list
 from pages.views import static_page_detail
-from projects.views import project_featured, project_list
+from projects.views import project_detail, project_featured, project_list
 
 
 def hello(request):
@@ -46,6 +46,7 @@ urlpatterns = [
     path("api/network/", network_member_list, name="network-member-list"),
     path("api/projects/", project_list, name="project-list"),
     path("api/projects/featured/", project_featured, name="project-featured"),
+    path("api/projects/<slug:slug>/", project_detail, name="project-detail"),
     path("api/blog/articles/", article_list, name="article-list"),
     path("api/blog/articles/<slug:slug>/", article_detail, name="article-detail"),
     path("api/pages/<slug:slug>/", static_page_detail, name="static-page-detail"),

--- a/backend/projects/migrations/0006_create_project_pages.py
+++ b/backend/projects/migrations/0006_create_project_pages.py
@@ -1,0 +1,122 @@
+"""Crée les Pages ProjectsIndexPage et ProjectPage et leur through-model de tags."""
+
+import django.db.models.deletion
+import modelcluster.contrib.taggit
+import modelcluster.fields
+import wagtail.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects", "0005_add_year_duration_credits"),
+        ("taggit", "0006_rename_taggeditem_content_type_object_id_taggit_tagg_content_8fc721_idx"),
+        ("wagtailcore", "0094_alter_page_locale"),
+        ("wagtailimages", "0027_image_description"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ProjectsIndexPage",
+            fields=[
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.page",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Index des projets",
+            },
+            bases=("wagtailcore.page",),
+        ),
+        migrations.CreateModel(
+            name="ProjectPage",
+            fields=[
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.page",
+                    ),
+                ),
+                ("description", wagtail.fields.RichTextField(blank=True, verbose_name="Description")),
+                ("youtube_url", models.URLField(verbose_name="Lien YouTube")),
+                ("year", models.CharField(blank=True, max_length=20, verbose_name="Année de création")),
+                ("video_duration", models.CharField(blank=True, max_length=50, verbose_name="Durée de la vidéo")),
+                ("credits", wagtail.fields.RichTextField(blank=True, verbose_name="Crédits")),
+                ("featured", models.BooleanField(default=False, verbose_name="À la une")),
+                (
+                    "thumbnail",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="+",
+                        to="wagtailimages.image",
+                        verbose_name="Miniature",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Projet",
+                "verbose_name_plural": "Projets",
+            },
+            bases=("wagtailcore.page",),
+        ),
+        migrations.CreateModel(
+            name="ProjectPageTag",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "content_object",
+                    modelcluster.fields.ParentalKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="tagged_items",
+                        to="projects.projectpage",
+                    ),
+                ),
+                (
+                    "tag",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(app_label)s_%(class)s_items",
+                        to="taggit.tag",
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        migrations.AddField(
+            model_name="projectpage",
+            name="tags",
+            field=modelcluster.contrib.taggit.ClusterTaggableManager(
+                blank=True,
+                help_text="A comma-separated list of tags.",
+                through="projects.ProjectPageTag",
+                to="taggit.Tag",
+                verbose_name="Tags",
+            ),
+        ),
+    ]

--- a/backend/projects/migrations/0007_migrate_projects_to_pages.py
+++ b/backend/projects/migrations/0007_migrate_projects_to_pages.py
@@ -1,0 +1,99 @@
+"""Migre les Projects (Snippet) vers des ProjectPages (Page Wagtail).
+
+Étapes :
+1. Crée la `ProjectsIndexPage` racine des projets (enfant de la `HomePage`).
+2. Pour chaque `Project` existant, crée une `ProjectPage` enfant avec slug
+   généré depuis le titre (collision-safe).
+3. Recopie titre, description, youtube_url, thumbnail, year, video_duration,
+   credits, featured et tags.
+
+La migration est idempotente : si une `ProjectPage` portant le même titre
+existe déjà sous la `ProjectsIndexPage`, le `Project` correspondant est ignoré.
+"""
+
+from django.db import migrations
+from django.utils.text import slugify
+
+
+def migrate_projects_to_pages(apps, schema_editor):
+    Project = apps.get_model("projects", "Project")
+    ProjectTag = apps.get_model("projects", "ProjectTag")
+
+    # La manipulation d'arbre Wagtail (add_child, MP_Node) requiert les
+    # modèles runtime, pas ceux retournés par apps.get_model.
+    from home.models import HomePage as RuntimeHomePage
+    from projects.models import ProjectPage as RuntimeProjectPage
+    from projects.models import ProjectsIndexPage as RuntimeProjectsIndexPage
+
+    home = RuntimeHomePage.objects.first()
+    if home is None:
+        return
+
+    projects_index = RuntimeProjectsIndexPage.objects.descendant_of(home).first()
+    if projects_index is None:
+        projects_index = RuntimeProjectsIndexPage(title="Projets", slug="projets")
+        home.add_child(instance=projects_index)
+        projects_index.save_revision().publish()
+
+    existing_slugs = set(projects_index.get_children().values_list("slug", flat=True))
+
+    for project in Project.objects.all().order_by("created_at"):
+        if (
+            RuntimeProjectPage.objects.descendant_of(projects_index)
+            .filter(title=project.title)
+            .exists()
+        ):
+            continue
+
+        base_slug = slugify(project.title) or "projet"
+        slug = base_slug
+        suffix = 2
+        while slug in existing_slugs:
+            slug = f"{base_slug}-{suffix}"
+            suffix += 1
+        existing_slugs.add(slug)
+
+        project_page = RuntimeProjectPage(
+            title=project.title,
+            slug=slug,
+            description=project.description,
+            youtube_url=project.youtube_url,
+            thumbnail=project.thumbnail,
+            year=project.year,
+            video_duration=project.video_duration,
+            credits=project.credits,
+            featured=project.featured,
+            first_published_at=project.created_at,
+            last_published_at=project.created_at,
+        )
+        projects_index.add_child(instance=project_page)
+
+        tag_names = list(
+            ProjectTag.objects.filter(content_object=project)
+            .values_list("tag__name", flat=True)
+        )
+        if tag_names:
+            project_page.tags.add(*tag_names)
+            project_page.save()
+
+
+def reverse_migrate(apps, schema_editor):
+    from projects.models import ProjectPage as RuntimeProjectPage
+    from projects.models import ProjectsIndexPage as RuntimeProjectsIndexPage
+
+    for page in list(RuntimeProjectPage.objects.all()):
+        page.delete()
+    for page in list(RuntimeProjectsIndexPage.objects.all()):
+        page.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects", "0006_create_project_pages"),
+        ("home", "0003_seed_home_page"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_projects_to_pages, reverse_code=reverse_migrate),
+    ]

--- a/backend/projects/migrations/0008_remove_project_snippet.py
+++ b/backend/projects/migrations/0008_remove_project_snippet.py
@@ -1,0 +1,28 @@
+"""Supprime l'ancien Snippet Project et son through-model ProjectTag.
+
+À jouer après la data migration 0007 qui a recopié les Projects dans des
+ProjectPages. Plus aucun code de l'application ne référence Project après
+cette migration.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("projects", "0007_migrate_projects_to_pages"),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name="project",
+            name="tags",
+        ),
+        migrations.DeleteModel(
+            name="ProjectTag",
+        ),
+        migrations.DeleteModel(
+            name="Project",
+        ),
+    ]

--- a/backend/projects/models.py
+++ b/backend/projects/models.py
@@ -1,32 +1,46 @@
 from django.core.exceptions import ValidationError
 from django.db import models
+from modelcluster.contrib.taggit import ClusterTaggableManager
 from modelcluster.fields import ParentalKey
-from modelcluster.models import ClusterableModel
-from modelcluster.tags import ClusterTaggableManager
 from taggit.models import TaggedItemBase
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
 from wagtail.images import get_image_model_string
-from wagtail.snippets.models import register_snippet
+from wagtail.models import Page
 
 MAX_FEATURED_PROJECTS = 3
 
 
-class ProjectTag(TaggedItemBase):
+class ProjectPageTag(TaggedItemBase):
     content_object = ParentalKey(
-        "projects.Project",
+        "projects.ProjectPage",
         on_delete=models.CASCADE,
         related_name="tagged_items",
     )
 
 
-@register_snippet
-class Project(ClusterableModel):
-    title = models.CharField("Titre", max_length=255)
+class ProjectsIndexPage(Page):
+    """Page de listing des projets. Parent unique des ProjectPage."""
+
+    content_panels = Page.content_panels
+
+    parent_page_types = ["home.HomePage"]
+    subpage_types = ["projects.ProjectPage"]
+    max_count = 1
+
+    preview_modes = []
+
+    class Meta:
+        verbose_name = "Index des projets"
+
+
+class ProjectPage(Page):
+    """Projet publié dans l'arbre Wagtail."""
+
     description = RichTextField("Description", blank=True)
     youtube_url = models.URLField("Lien YouTube")
     tags = ClusterTaggableManager(
-        through=ProjectTag,
+        through=ProjectPageTag,
         blank=True,
         verbose_name="Tags",
     )
@@ -42,10 +56,8 @@ class Project(ClusterableModel):
     video_duration = models.CharField("Durée de la vidéo", max_length=50, blank=True)
     credits = RichTextField("Crédits", blank=True)
     featured = models.BooleanField("À la une", default=False)
-    created_at = models.DateTimeField(auto_now_add=True)
 
-    panels = [
-        FieldPanel("title"),
+    content_panels = Page.content_panels + [
         FieldPanel("description"),
         FieldPanel("year"),
         FieldPanel("video_duration"),
@@ -56,18 +68,19 @@ class Project(ClusterableModel):
         FieldPanel("featured"),
     ]
 
+    parent_page_types = ["projects.ProjectsIndexPage"]
+    subpage_types = []
+
+    preview_modes = []
+
     class Meta:
-        ordering = ["-created_at"]
         verbose_name = "Projet"
         verbose_name_plural = "Projets"
-
-    def __str__(self):
-        return self.title
 
     def clean(self):
         super().clean()
         if self.featured:
-            qs = Project.objects.filter(featured=True)
+            qs = ProjectPage.objects.filter(featured=True)
             if self.pk:
                 qs = qs.exclude(pk=self.pk)
             if qs.count() >= MAX_FEATURED_PROJECTS:

--- a/backend/projects/tests/conftest.py
+++ b/backend/projects/tests/conftest.py
@@ -1,0 +1,44 @@
+import pytest
+from wagtail.models import Page, Site
+
+from home.models import HomePage
+from projects.models import ProjectPage, ProjectsIndexPage
+
+
+@pytest.fixture
+def projects_index(db):
+    """Retourne la ProjectsIndexPage, en reconstituant la chaîne d'arbre si besoin."""
+    existing = ProjectsIndexPage.objects.first()
+    if existing is not None:
+        return existing
+
+    home = HomePage.objects.first()
+    if home is None:
+        root = Page.objects.filter(depth=1).first()
+        if root is None:
+            root = Page.add_root(title="Root")
+        home = HomePage(title="Home", slug="home")
+        root.add_child(instance=home)
+        site = Site.objects.filter(is_default_site=True).first()
+        if site is not None:
+            site.root_page = home
+            site.save()
+
+    projects_index = ProjectsIndexPage(title="Projets", slug="projets")
+    home.add_child(instance=projects_index)
+    return projects_index
+
+
+@pytest.fixture
+def make_project(projects_index):
+    """Crée un ProjectPage publié sous la ProjectsIndexPage. Slug auto-incrémenté."""
+    counter = {"n": 0}
+
+    def _make(title="Projet", youtube_url="https://youtube.com/watch?v=test", **kwargs):
+        counter["n"] += 1
+        kwargs.setdefault("slug", f"projet-{counter['n']}")
+        project = ProjectPage(title=title, youtube_url=youtube_url, **kwargs)
+        projects_index.add_child(instance=project)
+        return project
+
+    return _make

--- a/backend/projects/tests/test_projects.py
+++ b/backend/projects/tests/test_projects.py
@@ -1,40 +1,43 @@
+import json
+
 import pytest
 from django.core.exceptions import ValidationError
-from django.test import Client
+from django.http import Http404
+from django.test import RequestFactory
 
-from projects.models import MAX_FEATURED_PROJECTS, Project
+from projects.models import MAX_FEATURED_PROJECTS, ProjectPage, ProjectPageTag
+from projects.views import project_detail, project_featured, project_list
 
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
 class TestProjectListView:
-    url = "/api/projects/"
+    def test_empty_list(self, rf, projects_index):
+        request = rf.get("/api/projects/")
+        response = project_list(request)
+        assert response.status_code == 200
+        assert json.loads(response.content) == []
 
-    def test_empty_list(self, client: Client):
-        resp = client.get(self.url)
-        assert resp.status_code == 200
-        assert resp.json() == []
+    def test_returns_projects(self, rf, make_project):
+        make_project(title="Spectacle A", youtube_url="https://youtube.com/watch?v=aaa")
+        make_project(title="Spectacle B", youtube_url="https://youtube.com/watch?v=bbb")
 
-    def test_returns_projects(self, client: Client):
-        Project.objects.create(
-            title="Spectacle A",
-            youtube_url="https://youtube.com/watch?v=aaa",
-        )
-        Project.objects.create(
-            title="Spectacle B",
-            youtube_url="https://youtube.com/watch?v=bbb",
-        )
-
-        resp = client.get(self.url)
-        data = resp.json()
+        response = project_list(rf.get("/api/projects/"))
+        data = json.loads(response.content)
 
         assert len(data) == 2
         titles = {p["title"] for p in data}
         assert titles == {"Spectacle A", "Spectacle B"}
 
-    def test_project_fields(self, client: Client):
-        Project.objects.create(
+    def test_project_fields(self, rf, make_project):
+        project = make_project(
             title="Mon projet",
+            slug="mon-projet",
             description="<p>Description du projet</p>",
             youtube_url="https://youtube.com/watch?v=xyz",
             year="2024",
@@ -42,135 +45,168 @@ class TestProjectListView:
             credits="<p>Réalisation : Jean Dupont</p>",
         )
 
-        resp = client.get(self.url)
-        project = resp.json()[0]
+        response = project_list(rf.get("/api/projects/"))
+        data = json.loads(response.content)
+        assert len(data) == 1
+        item = data[0]
 
-        assert project["title"] == "Mon projet"
-        assert "Description du projet" in project["description"]
-        assert project["youtube_url"] == "https://youtube.com/watch?v=xyz"
-        assert project["tags"] == []
-        assert project["thumbnail_url"] is None
-        assert project["year"] == "2024"
-        assert project["video_duration"] == "3min30"
-        assert "Réalisation : Jean Dupont" in project["credits"]
+        assert item["id"] == project.pk
+        assert item["slug"] == "mon-projet"
+        assert item["title"] == "Mon projet"
+        assert "Description du projet" in item["description"]
+        assert item["youtube_url"] == "https://youtube.com/watch?v=xyz"
+        assert item["tags"] == []
+        assert item["thumbnail_url"] is None
+        assert item["year"] == "2024"
+        assert item["video_duration"] == "3min30"
+        assert "Réalisation : Jean Dupont" in item["credits"]
 
-    def test_project_optional_fields_empty(self, client: Client):
-        Project.objects.create(
-            title="Projet sans extras",
-            youtube_url="https://youtube.com/watch?v=abc",
+    def test_project_optional_fields_empty(self, rf, make_project):
+        make_project(title="Projet sans extras", slug="projet-sans-extras")
+
+        response = project_list(rf.get("/api/projects/"))
+        item = json.loads(response.content)[0]
+
+        assert item["year"] == ""
+        assert item["video_duration"] == ""
+        assert item["credits"] == ""
+
+    def test_ordering_newest_first(self, rf, make_project):
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        old = make_project(title="Old")
+        ProjectPage.objects.filter(pk=old.pk).update(
+            first_published_at=timezone.now() - timedelta(days=1)
         )
+        make_project(title="New")
 
-        resp = client.get(self.url)
-        project = resp.json()[0]
-
-        assert project["year"] == ""
-        assert project["video_duration"] == ""
-        assert project["credits"] == ""
-
-    def test_ordering_newest_first(self, client: Client):
-        Project.objects.create(title="Old", youtube_url="https://youtube.com/watch?v=1")
-        Project.objects.create(title="New", youtube_url="https://youtube.com/watch?v=2")
-
-        resp = client.get(self.url)
-        data = resp.json()
+        response = project_list(rf.get("/api/projects/"))
+        data = json.loads(response.content)
         assert data[0]["title"] == "New"
         assert data[1]["title"] == "Old"
 
-    def test_post_not_allowed(self, client: Client):
-        resp = client.post(self.url)
-        assert resp.status_code == 405
+    def test_only_get_allowed(self, rf):
+        response = project_list(rf.post("/api/projects/"))
+        assert response.status_code == 405
+
+    def test_does_not_return_drafts(self, rf, make_project):
+        live = make_project(title="Live")
+        draft = make_project(title="Draft")
+        draft.unpublish()
+
+        response = project_list(rf.get("/api/projects/"))
+        data = json.loads(response.content)
+        assert len(data) == 1
+        assert data[0]["title"] == "Live"
 
 
 class TestProjectFeaturedView:
-    url = "/api/projects/featured/"
+    def test_empty_when_no_featured(self, rf, make_project):
+        make_project(title="Not featured", featured=False)
 
-    def test_empty_when_no_featured(self, client: Client):
-        Project.objects.create(
-            title="Not featured",
-            youtube_url="https://youtube.com/watch?v=aaa",
-            featured=False,
-        )
-        resp = client.get(self.url)
-        assert resp.status_code == 200
-        assert resp.json() == []
+        response = project_featured(rf.get("/api/projects/featured/"))
+        assert response.status_code == 200
+        assert json.loads(response.content) == []
 
-    def test_returns_only_featured(self, client: Client):
-        Project.objects.create(
-            title="Featured",
-            youtube_url="https://youtube.com/watch?v=aaa",
-            featured=True,
-        )
-        Project.objects.create(
-            title="Not featured",
-            youtube_url="https://youtube.com/watch?v=bbb",
-            featured=False,
-        )
-        resp = client.get(self.url)
-        data = resp.json()
+    def test_returns_only_featured(self, rf, make_project):
+        make_project(title="Featured", featured=True)
+        make_project(title="Not featured", featured=False)
+
+        response = project_featured(rf.get("/api/projects/featured/"))
+        data = json.loads(response.content)
         assert len(data) == 1
         assert data[0]["title"] == "Featured"
 
-    def test_post_not_allowed(self, client: Client):
-        resp = client.post(self.url)
-        assert resp.status_code == 405
+    def test_only_get_allowed(self, rf, projects_index):
+        response = project_featured(rf.post("/api/projects/featured/"))
+        assert response.status_code == 405
 
 
-class TestProjectModel:
-    def test_str(self, db):
-        project = Project(title="Mon spectacle")
+class TestProjectDetailView:
+    def test_returns_project_by_slug(self, rf, make_project):
+        proj = make_project(
+            title="Mon projet",
+            slug="mon-projet",
+            youtube_url="https://youtube.com/watch?v=abc",
+            year="2024",
+        )
+        proj.tags.add("tag1")
+        proj.save()
+
+        response = project_detail(rf.get("/api/projects/mon-projet/"), slug="mon-projet")
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["slug"] == "mon-projet"
+        assert data["title"] == "Mon projet"
+        assert data["year"] == "2024"
+        assert data["tags"] == ["tag1"]
+
+    def test_returns_404_for_unknown_slug(self, rf, projects_index):
+        with pytest.raises(Http404):
+            project_detail(rf.get("/api/projects/unknown/"), slug="unknown")
+
+    def test_does_not_return_drafts(self, rf, make_project):
+        proj = make_project(title="Brouillon", slug="brouillon")
+        proj.unpublish()
+
+        with pytest.raises(Http404):
+            project_detail(rf.get("/api/projects/brouillon/"), slug="brouillon")
+
+    def test_only_get_allowed(self, rf, projects_index):
+        response = project_detail(rf.post("/api/projects/test/"), slug="test")
+        assert response.status_code == 405
+
+
+class TestProjectPageModel:
+    def test_str(self, make_project):
+        project = make_project(title="Mon spectacle")
         assert str(project) == "Mon spectacle"
 
-    def test_featured_default_false(self, db):
-        project = Project.objects.create(
-            title="Test", youtube_url="https://youtube.com/watch?v=x"
-        )
+    def test_featured_default_false(self, make_project):
+        project = make_project(title="Test")
         assert project.featured is False
 
-    def test_featured_max_validation(self, db):
+    def test_tags(self, make_project):
+        project = make_project(title="Projet taggué")
+        project.tags.add("wagtail", "django")
+        project.save()
+        assert set(project.tags.names()) == {"wagtail", "django"}
+
+    def test_project_page_tag_model(self, make_project):
+        project = make_project(title="Test tag model")
+        project.tags.add("test-tag")
+        project.save()
+        assert ProjectPageTag.objects.filter(content_object=project).exists()
+
+    def test_parent_is_projects_index(self, make_project, projects_index):
+        project = make_project(title="Sous ProjectsIndex")
+        assert project.get_parent().specific == projects_index
+
+    def test_featured_max_validation(self, make_project):
         for i in range(MAX_FEATURED_PROJECTS):
-            Project.objects.create(
-                title=f"Featured {i}",
-                youtube_url=f"https://youtube.com/watch?v={i}",
-                featured=True,
-            )
-        extra = Project(
-            title="One too many",
-            youtube_url="https://youtube.com/watch?v=extra",
-            featured=True,
-        )
+            make_project(title=f"Featured {i}", featured=True)
+        extra = make_project(title="One too many", featured=False)
+        extra.featured = True
         with pytest.raises(ValidationError) as exc_info:
             extra.clean()
         assert "featured" in exc_info.value.message_dict
 
-    def test_featured_max_validation_on_save(self, db):
-        """save() must also enforce the max featured constraint."""
+    def test_featured_max_validation_on_save(self, make_project):
+        """save() doit aussi appliquer la contrainte max featured."""
         for i in range(MAX_FEATURED_PROJECTS):
-            Project.objects.create(
-                title=f"Featured {i}",
-                youtube_url=f"https://youtube.com/watch?v={i}",
-                featured=True,
-            )
-        extra = Project(
-            title="One too many",
-            youtube_url="https://youtube.com/watch?v=extra",
-            featured=True,
-        )
+            make_project(title=f"Featured {i}", featured=True)
+        extra = make_project(title="One too many", featured=False)
+        extra.featured = True
         with pytest.raises(ValidationError) as exc_info:
             extra.save()
         assert "featured" in exc_info.value.message_dict
-        assert Project.objects.filter(featured=True).count() == MAX_FEATURED_PROJECTS
+        assert ProjectPage.objects.filter(featured=True).count() == MAX_FEATURED_PROJECTS
 
-    def test_featured_allows_update_existing(self, db):
-        project = Project.objects.create(
-            title="Already featured",
-            youtube_url="https://youtube.com/watch?v=x",
-            featured=True,
-        )
+    def test_featured_allows_update_existing(self, make_project):
+        project = make_project(title="Already featured", featured=True)
         for i in range(MAX_FEATURED_PROJECTS - 1):
-            Project.objects.create(
-                title=f"Featured {i}",
-                youtube_url=f"https://youtube.com/watch?v={i}",
-                featured=True,
-            )
+            make_project(title=f"Featured {i}", featured=True)
         # Re-saving an existing featured project should not raise
         project.save()

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1,49 +1,65 @@
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
 from django.views.decorators.http import require_GET
 from wagtail.rich_text import expand_db_html
 
-from .models import Project
+from .models import ProjectPage
 
 
 def _base_queryset():
-    """Return the base Project queryset with common prefetches."""
-    return Project.objects.prefetch_related("tags").select_related("thumbnail")
+    """Return the base ProjectPage queryset with common prefetches."""
+    return (
+        ProjectPage.objects.live()
+        .order_by("-first_published_at")
+        .prefetch_related("tags")
+        .select_related("thumbnail")
+    )
+
+
+def _serialize_project(request, project):
+    return {
+        "id": project.pk,
+        "slug": project.slug,
+        "title": project.title,
+        "description": expand_db_html(project.description) if project.description else "",
+        "youtube_url": project.youtube_url,
+        "tags": [tag.name for tag in project.tags.all()],
+        "thumbnail_url": (
+            request.build_absolute_uri(
+                project.thumbnail.get_rendition("fill-600x400").url
+            )
+            if project.thumbnail
+            else None
+        ),
+        "year": project.year,
+        "video_duration": project.video_duration,
+        "credits": expand_db_html(project.credits) if project.credits else "",
+    }
 
 
 def _serialize_projects(request, projects):
-    """Serialize a queryset of projects to a list of dicts."""
-    return [
-        {
-            "id": project.pk,
-            "title": project.title,
-            "description": expand_db_html(project.description) if project.description else "",
-            "youtube_url": project.youtube_url,
-            "tags": [tag.name for tag in project.tags.all()],
-            "thumbnail_url": (
-                request.build_absolute_uri(
-                    project.thumbnail.get_rendition("fill-600x400").url
-                )
-                if project.thumbnail
-                else None
-            ),
-            "year": project.year,
-            "video_duration": project.video_duration,
-            "credits": expand_db_html(project.credits) if project.credits else "",
-        }
-        for project in projects
-    ]
+    return [_serialize_project(request, p) for p in projects]
 
 
 @require_GET
 def project_list(request):
-    """Return all projects as JSON."""
-    return JsonResponse(_serialize_projects(request, _base_queryset().all()), safe=False)
+    """Return all live projects as JSON."""
+    return JsonResponse(_serialize_projects(request, _base_queryset()), safe=False)
 
 
 @require_GET
 def project_featured(request):
-    """Return featured projects as JSON."""
+    """Return featured live projects as JSON."""
     return JsonResponse(
         _serialize_projects(request, _base_queryset().filter(featured=True)),
         safe=False,
     )
+
+
+@require_GET
+def project_detail(request, slug):
+    """Return a single live project by slug."""
+    try:
+        project = _base_queryset().get(slug=slug)
+    except ProjectPage.DoesNotExist:
+        raise Http404
+    return JsonResponse(_serialize_project(request, project))

--- a/frontend/app/components/ProjectsSection.tsx
+++ b/frontend/app/components/ProjectsSection.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 
 interface Project {
   id: number;
+  slug: string;
   title: string;
   tags: string[];
   thumbnail_url: string | null;
@@ -43,7 +44,7 @@ export default function ProjectsSection() {
         {projects.map((project) => (
           <Link
             key={project.id}
-            href={`/projets/${project.id}`}
+            href={`/projets/${project.slug}`}
             className={`projects-section__card${!project.thumbnail_url ? ' projects-section__card--no-thumbnail' : ''}`}
           >
             {project.thumbnail_url && (

--- a/frontend/app/projets/[slug]/page.tsx
+++ b/frontend/app/projets/[slug]/page.tsx
@@ -15,13 +15,13 @@ function extractYouTubeId(url: string): string | null {
 }
 
 export default function ProjectDetailPage() {
-  const params = useParams<{ id: string }>();
+  const params = useParams<{ slug: string }>();
   const [project, setProject] = useState<Project | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const controller = new AbortController();
-    fetch(`${API_URL}/api/projects/`, {
+    fetch(`${API_URL}/api/projects/${params.slug}/`, {
       credentials: 'include',
       signal: controller.signal,
     })
@@ -29,18 +29,13 @@ export default function ProjectDetailPage() {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
-      .then((data) => {
-        if (Array.isArray(data)) {
-          const match = data.find((p: Project) => String(p.id) === params.id) || null;
-          setProject(match);
-        }
-      })
+      .then((data) => setProject(data))
       .catch((err) => {
         if (err.name !== 'AbortError') setProject(null);
       })
       .finally(() => setLoading(false));
     return () => controller.abort();
-  }, [params.id]);
+  }, [params.slug]);
 
   if (loading) {
     return (

--- a/frontend/app/projets/page.tsx
+++ b/frontend/app/projets/page.tsx
@@ -73,7 +73,7 @@ export default function ProjetsPage() {
           {filtered.map((project, i) => (
             <Link
               key={project.id}
-              href={`/projets/${project.id}`}
+              href={`/projets/${project.slug}`}
               className={`project-card${!project.thumbnail_url ? ' project-card--no-thumbnail' : ''}`}
               style={{ animationDelay: `${i * 0.04}s` }}
             >

--- a/frontend/app/types/project.ts
+++ b/frontend/app/types/project.ts
@@ -1,5 +1,6 @@
 export interface Project {
   id: number;
+  slug: string;
   title: string;
   description: string;
   youtube_url: string;


### PR DESCRIPTION
## Summary

- Replaces the `Project` ClusterableModel snippet with `ProjectPage(Page)` under `ProjectsIndexPage`, aligned with how blog articles were migrated in #122
- API contract preserved (`id`, `title`, `description`, `youtube_url`, `tags`, `thumbnail_url`, `year`, `video_duration`, `credits`) + `slug` added; new `GET /api/projects/<slug>/` detail endpoint
- Frontend routes switched from `/projets/[id]` → `/projets/[slug]`; detail page now fetches the new slug endpoint directly

## Changes

**Backend**
- `projects/models.py`: `ProjectsIndexPage(Page)` + `ProjectPage(Page)` replace `Project` snippet; `featured` field + `clean()` max-3 validation kept (Option A)
- Migrations 0006–0008: create pages, data-migrate, remove old snippet
- `projects/views.py`: query `ProjectPage.objects.live()`, add `slug` to output, new `project_detail` view
- `config/urls.py`: register `GET /api/projects/<slug>/`

**Frontend**
- `types/project.ts`: add `slug: string`
- `app/projets/[id]/page.tsx` → `[slug]/page.tsx`
- `app/projets/page.tsx` + `ProjectsSection.tsx`: links use `project.slug`

**Tests**
- `projects/tests/conftest.py`: new `projects_index` + `make_project` fixtures
- `projects/tests/test_projects.py`: full rewrite for Page model — 22 tests covering list, featured, detail, model validation including max-3 featured regression (PROJ-05 / #80)

## Test plan

- [x] `pytest projects/` → 22 passed
- [x] Full test suite → 91 passed, 0 failures
- [ ] Apply migrations on a fresh DB and verify data migration runs cleanly
- [ ] Smoke-test `/projets` list and `/projets/<slug>` detail in the browser
- [ ] Verify "À la une" projects appear on the home page

## Notes

> **Prod ops**: take a DB dump before running `migrate` in production (as noted in the issue).

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)