### PR TITLE
fix(projects): use thumbnail_id in data migration to avoid FK class m…

### DIFF
--- a/backend/projects/migrations/0007_migrate_projects_to_pages.py
+++ b/backend/projects/migrations/0007_migrate_projects_to_pages.py
@@ -58,7 +58,7 @@ def migrate_projects_to_pages(apps, schema_editor):
             slug=slug,
             description=project.description,
             youtube_url=project.youtube_url,
-            thumbnail=project.thumbnail,
+            thumbnail_id=project.thumbnail_id,
             year=project.year,
             video_duration=project.video_duration,
             credits=project.credits,


### PR DESCRIPTION
…ismatch

When the historical Project queryset (apps.get_model) returns a thumbnail instance, its model class differs from the runtime Image model expected by ProjectPage, causing a ValueError. Assigning thumbnail_id (the raw integer) bypasses the isinstance check entirely.