### PR TITLE
feat(preview): activer la preview headless Wagtail via Next.js

### DIFF
--- a/backend/blog/models.py
+++ b/backend/blog/models.py
@@ -6,6 +6,7 @@ from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
 from wagtail.images import get_image_model_string
 from wagtail.models import Page
+from wagtail_headless_preview.models import HeadlessPreviewMixin
 
 
 class ArticlePageTag(TaggedItemBase):
@@ -29,14 +30,14 @@ class BlogIndexPage(Page):
     subpage_types = ["blog.ArticlePage"]
     max_count = 1
 
-    # Pas de preview headless dans cette PR (voir #121)
+    # Pas de preview headless pour la page de listing
     preview_modes = []
 
     class Meta:
         verbose_name = "Index de blog"
 
 
-class ArticlePage(Page):
+class ArticlePage(HeadlessPreviewMixin, Page):
     """Article de blog publié dans l'arbre Wagtail."""
 
     summary = models.TextField("Résumé", blank=True)
@@ -64,9 +65,6 @@ class ArticlePage(Page):
 
     parent_page_types = ["blog.BlogIndexPage"]
     subpage_types = []
-
-    # Pas de preview headless dans cette PR (voir #121)
-    preview_modes = []
 
     class Meta:
         verbose_name = "Article"

--- a/backend/blog/tests/test_preview.py
+++ b/backend/blog/tests/test_preview.py
@@ -1,0 +1,101 @@
+import json
+
+import pytest
+from django.http import Http404
+from django.test import RequestFactory
+
+from blog.views import article_preview_draft
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+class TestArticlePreviewDraftEndpoint:
+    def test_returns_draft_content_with_valid_token(self, rf, make_article):
+        article = make_article(title="Brouillon non publié", content="<p>contenu brouillon</p>")
+        article.unpublish()
+
+        page_preview = article.create_page_preview()
+        page_preview.save()
+
+        request = rf.get("/api/preview/draft/", {"token": page_preview.token})
+        response = article_preview_draft(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["title"] == "Brouillon non publié"
+        assert "<p>" in data["content"]
+        assert data["slug"] == article.slug
+
+    def test_returns_draft_content_for_unpublished_article(self, rf, make_article):
+        article = make_article(title="Jamais publié", content="<p>contenu</p>")
+        article.unpublish()
+
+        page_preview = article.create_page_preview()
+        page_preview.save()
+
+        request = rf.get("/api/preview/draft/", {"token": page_preview.token})
+        response = article_preview_draft(request)
+        data = json.loads(response.content)
+
+        assert data["id"] == article.pk
+        assert data["title"] == "Jamais publié"
+
+    def test_missing_token_raises_404(self, rf):
+        request = rf.get("/api/preview/draft/")
+        with pytest.raises(Http404):
+            article_preview_draft(request)
+
+    def test_invalid_token_raises_404(self, rf):
+        request = rf.get("/api/preview/draft/", {"token": "token-invalide"})
+        with pytest.raises(Http404):
+            article_preview_draft(request)
+
+    def test_tampered_token_raises_404(self, rf, make_article):
+        article = make_article(title="Article test", content="<p>x</p>")
+        page_preview = article.create_page_preview()
+        page_preview.save()
+
+        tampered = page_preview.token + "tampered"
+        request = rf.get("/api/preview/draft/", {"token": tampered})
+        with pytest.raises(Http404):
+            article_preview_draft(request)
+
+    def test_response_fields(self, rf, make_article):
+        article = make_article(
+            title="Article preview",
+            slug="article-preview",
+            summary="Résumé brouillon",
+            content="<p>Contenu brouillon</p>",
+        )
+        article.tags.add("preview", "test")
+        article.save()
+
+        page_preview = article.create_page_preview()
+        page_preview.save()
+
+        request = rf.get("/api/preview/draft/", {"token": page_preview.token})
+        response = article_preview_draft(request)
+        data = json.loads(response.content)
+
+        assert data["slug"] == "article-preview"
+        assert data["summary"] == "Résumé brouillon"
+        assert data["illustration_url"] is None
+        assert set(data["tags"]) == {"preview", "test"}
+
+
+class TestPreviewVsPublicApi:
+    def test_draft_not_accessible_via_public_api(self, rf, make_article):
+        """Un brouillon accessible en preview ne doit pas apparaître dans l'API publique."""
+        from blog.views import article_detail
+
+        article = make_article(title="Brouillon", slug="brouillon", content="<p>x</p>")
+        article.unpublish()
+
+        request = rf.get("/api/blog/articles/brouillon/")
+        with pytest.raises(Http404):
+            article_detail(request, slug="brouillon")

--- a/backend/blog/views.py
+++ b/backend/blog/views.py
@@ -65,3 +65,27 @@ def article_detail(request, slug):
         raise Http404("Article introuvable") from exc
 
     return JsonResponse(_serialize_article(request, article))
+
+
+@require_GET
+def article_preview_draft(request):
+    """Retourne les données brouillon d'un ArticlePage pour la preview headless.
+
+    Authentifié par token signé (créé par wagtail-headless-preview lors du clic Aperçu).
+    Le token fait office de credential — aucune session Django requise.
+    """
+    from django.core.signing import BadSignature
+
+    token = request.GET.get("token")
+    if not token:
+        raise Http404("Token manquant")
+
+    try:
+        page = ArticlePage.get_page_from_preview_token(token)
+    except BadSignature:
+        raise Http404("Token invalide")
+
+    if page is None:
+        raise Http404("Token introuvable ou expiré")
+
+    return JsonResponse(_serialize_article(request, page))

--- a/backend/config/middleware.py
+++ b/backend/config/middleware.py
@@ -21,6 +21,7 @@ class LoginRequiredMiddleware:
         "/admin/",
         "/django-admin/",
         "/api/auth/",
+        "/api/preview/",
         "/documents/",
         "/static/",
         "/media/",

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -27,6 +27,8 @@ INSTALLED_APPS = [
     "projects",
     "site_settings",
 
+    "wagtail_headless_preview",
+
     "wagtail.contrib.forms",
     "wagtail.contrib.settings",
     "wagtail.contrib.redirects",
@@ -114,6 +116,14 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 WAGTAIL_SITE_NAME = "culturall-website"
 WAGTAILADMIN_BASE_URL = os.environ.get("WAGTAILADMIN_BASE_URL", "http://localhost:8000")
 WAGTAILDOCS_EXTENSIONS = ["csv", "docx", "key", "odt", "pdf", "pptx", "rtf", "txt", "xlsx", "zip"]
+
+# ─── Headless Preview ──────────────────────────────────────────
+_FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:3000")
+WAGTAIL_HEADLESS_PREVIEW = {
+    "CLIENT_URLS": {
+        "default": f"{_FRONTEND_URL}/api/preview",
+    },
+}
 
 # ─── CORS ─────────────────────────────────────────────────────
 CORS_ALLOWED_ORIGINS = [

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -7,7 +7,7 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
-from blog.views import article_detail, article_list
+from blog.views import article_detail, article_list, article_preview_draft
 from home.auth_views import auth_check, auth_login, auth_logout
 from home.views import contact_submit
 from network.views import network_member_list
@@ -48,6 +48,7 @@ urlpatterns = [
     path("api/projects/featured/", project_featured, name="project-featured"),
     path("api/blog/articles/", article_list, name="article-list"),
     path("api/blog/articles/<slug:slug>/", article_detail, name="article-detail"),
+    path("api/preview/draft/", article_preview_draft, name="article-preview-draft"),
     path("api/pages/<slug:slug>/", static_page_detail, name="static-page-detail"),
 
     # Catch-all Wagtail (page tree) — désactivé : on est headless, Next.js

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ gunicorn>=22.0,<23.0
 whitenoise[brotli]>=6.7,<7.0
 django-storages[s3]>=1.14,<2.0
 django-cors-headers>=4.4,<5.0
+wagtail-headless-preview>=0.7.0,<1.0
 pytest>=8.0,<9.0
 pytest-django>=4.8,<5.0
 factory-boy>=3.3,<4.0

--- a/frontend/app/api/preview/route.ts
+++ b/frontend/app/api/preview/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const INTERNAL_API_URL =
+  process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://django:8000';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const token = searchParams.get('token');
+
+  if (!token) {
+    return NextResponse.json({ error: 'Token manquant' }, { status: 400 });
+  }
+
+  // Valide le token et récupère les données brouillon (dont le slug)
+  let res: Response;
+  try {
+    res = await fetch(
+      `${INTERNAL_API_URL}/api/preview/draft/?token=${encodeURIComponent(token)}`,
+      { cache: 'no-store' },
+    );
+  } catch {
+    return NextResponse.json({ error: 'Backend inaccessible' }, { status: 502 });
+  }
+
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Token invalide ou expiré' }, { status: 404 });
+  }
+
+  const data = await res.json();
+  const slug: string = data.slug;
+
+  // Redirige vers la page article avec le token en query param
+  // Le token fait office de credential — la page client l'utilise pour fetcher le brouillon
+  const previewUrl = new URL(`/blog/${slug}`, request.url);
+  previewUrl.searchParams.set('preview_token', token);
+
+  return NextResponse.redirect(previewUrl);
+}

--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -2,20 +2,28 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import { Article } from '../../types/article';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
 
 export default function ArticleDetailPage() {
   const params = useParams<{ slug: string }>();
+  const searchParams = useSearchParams();
+  const previewToken = searchParams.get('preview_token');
+
   const [article, setArticle] = useState<Article | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!params.slug) return;
     const controller = new AbortController();
-    fetch(`${API_URL}/api/blog/articles/${encodeURIComponent(params.slug)}/`, {
+
+    const url = previewToken
+      ? `${API_URL}/api/preview/draft/?token=${encodeURIComponent(previewToken)}`
+      : `${API_URL}/api/blog/articles/${encodeURIComponent(params.slug)}/`;
+
+    fetch(url, {
       credentials: 'include',
       signal: controller.signal,
     })
@@ -32,7 +40,7 @@ export default function ArticleDetailPage() {
       })
       .finally(() => setLoading(false));
     return () => controller.abort();
-  }, [params.slug]);
+  }, [params.slug, previewToken]);
 
   if (loading) {
     return (
@@ -59,6 +67,14 @@ export default function ArticleDetailPage() {
 
   return (
     <div className="page blog-page">
+      {previewToken && (
+        <div className="preview-banner" role="status">
+          <span>Mode aperçu — ce contenu n&apos;est pas encore publié</span>
+          <Link href={`/blog/${params.slug}`} className="preview-banner__exit">
+            Quitter l&apos;aperçu
+          </Link>
+        </div>
+      )}
       <div className="article-detail-wrapper">
         <Link href="/blog" className="article-detail__back">
           <span className="article-detail__back-icon" aria-hidden="true">←</span>

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -890,6 +890,32 @@ body {
   opacity: 1;
 }
 
+/* Preview banner */
+.preview-banner {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 0.6rem 1rem;
+  background: #b45309;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.preview-banner__exit {
+  color: #fff;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.preview-banner__exit:hover {
+  opacity: 0.8;
+}
+
 /* Blog page */
 .blog-page {
   background: #111;


### PR DESCRIPTION
## Résumé

Fixes #121 — Active le bouton « Aperçu » de l'admin Wagtail pour les `ArticlePage` en intégrant `wagtail-headless-preview`.

- **Backend** : `ArticlePage` hérite de `HeadlessPreviewMixin` ; nouvel endpoint `GET /api/preview/draft/?token=<token>` qui valide le token signé et retourne le brouillon au même format JSON que l'API publique
- **Frontend** : route API `/api/preview` qui valide le token côté serveur, redirige vers `/blog/<slug>?preview_token=<token>` ; la page article détecte le token, fetch le brouillon et affiche une bannière orange « Mode aperçu »
- **Tests** : 7 nouveaux tests backend (token valide, invalide, altéré, champs de réponse, isolation brouillon/API publique) — 29/29 passent

### Flow complet

```
Admin Wagtail → clic « Aperçu »
  → Wagtail crée un token signé (TimestampSigner)
  → Redirige vers http://localhost:3000/api/preview?content_type=blog.articlepage&token=<token>
  → Next.js valide le token via /api/preview/draft/, récupère le slug
  → Redirige vers /blog/<slug>?preview_token=<token>
  → Page article affiche le brouillon + bannière « Mode aperçu »
```

### Sécurité

- Le token est signé par `TimestampSigner` (Django) — impossible à forger sans la `SECRET_KEY`
- Les visiteurs publics ne peuvent accéder qu'à `/api/blog/articles/<slug>/` qui ne retourne que les pages `.live()` — les brouillons restent inaccessibles sans token
- L'endpoint `/api/preview/draft/` renvoie 404 pour tout token absent, invalide ou altéré

### Hors périmètre (selon l'issue)

- ProjectPage (dépend de #119, non encore mergé)
- Preview pour les Snippets (`StaticPage`, `NetworkMember`)
- Internationalisation

## Test plan

- [ ] Démarrer l'environnement dev, créer un `ArticlePage` en brouillon dans l'admin Wagtail
- [ ] Cliquer « Aperçu » → un onglet s'ouvre sur `/blog/<slug>?preview_token=...` avec le contenu brouillon et la bannière orange
- [ ] Vérifier que le slug sans `preview_token` ne retourne pas le brouillon (404 ou contenu publié uniquement)
- [ ] Vérifier que la bannière « Quitter l'aperçu » redirige vers la page publiée
- [ ] `pytest blog/tests/` — 29 tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)