### PR TITLE
fix(preview): exposer FRONTEND_URL au container Django

### DIFF
--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -21,6 +21,7 @@ services:
       - DEBUG
       - ALLOWED_HOSTS
       - DATABASE_URL
+      - FRONTEND_URL
       - MINIO_ROOT_USER
       - MINIO_ROOT_PASSWORD
       - MINIO_ENDPOINT_URL


### PR DESCRIPTION
## Problème

`FRONTEND_URL` avait été ajoutée à `.env.prod` / `.env.dev` pour configurer `WAGTAIL_HEADLESS_PREVIEW`, mais le bloc environment: de docker-compose.base.yml ne déclare que les variables explicitement listées — sans cette ligne, docker compose ne propageait pas la var au container, et `WAGTAIL_HEADLESS_PREVIEW.CLIENT_URLS.default` retombait sur le défaut `http://localhost:3000`.

Résultat : en prod, le bouton « Aperçu » redirigeait vers localhost:3000 (inaccessible depuis le navigateur du rédacteur).

## Fix

Ajoute `FRONTEND_URL` à la liste des env vars exposées au container Django.

## Déploiement

Après merge, sur le VPS :

```
docker compose -p culturall-website \
  -f docker-compose.base.yml \
  -f docker-compose.prod.yml \
  --env-file .env.prod \
  up -d --force-recreate django
```

## Test plan

- [ ] Vérifier que `docker exec <django-container> env | grep FRONTEND_URL` retourne la valeur configurée
- [ ] Cliquer « Aperçu » sur un article brouillon en prod → ouvre la preview sur le bon domaine

🤖 Generated with [Claude Code](https://claude.com/claude-code)