### PR TITLE
fix(preview): redirection vers le bon host derrière Traefik

### DIFF
--- a/frontend/app/preview/route.ts
+++ b/frontend/app/preview/route.ts
@@ -3,6 +3,18 @@ import { NextRequest, NextResponse } from 'next/server';
 const INTERNAL_API_URL =
   process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://django:8000';
 
+/**
+ * Reconstruit l'URL externe de la requête à partir des headers X-Forwarded-*
+ * (posés par Traefik en prod). Sans ça, request.url retombe sur l'adresse
+ * interne du container (0.0.0.0:3000), ce qui casse les redirections en prod.
+ */
+function getExternalBaseUrl(request: NextRequest): string {
+  const host = request.headers.get('x-forwarded-host') || request.headers.get('host');
+  const proto = request.headers.get('x-forwarded-proto') || 'https';
+  if (host) return `${proto}://${host}`;
+  return request.nextUrl.origin;
+}
+
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
   const token = searchParams.get('token');
@@ -31,7 +43,7 @@ export async function GET(request: NextRequest) {
 
   // Redirige vers la page article avec le token en query param
   // Le token fait office de credential — la page client l'utilise pour fetcher le brouillon
-  const previewUrl = new URL(`/blog/${slug}`, request.url);
+  const previewUrl = new URL(`/blog/${slug}`, getExternalBaseUrl(request));
   previewUrl.searchParams.set('preview_token', token);
 
   return NextResponse.redirect(previewUrl);


### PR DESCRIPTION
## Problème

En prod derrière Traefik, l'iframe de preview chargeait `https://0.0.0.0:3000/blog/<slug>?preview_token=...` au lieu de `https://cultur-all.org/blog/<slug>?...`, d'où un `NS_ERROR_CONNECTION_REFUSED` côté navigateur.

Cause : dans `frontend/app/preview/route.ts`, la redirection utilisait `new URL(path, request.url)`. Or `request.url` côté Next.js dans le container retombe sur l'adresse interne `0.0.0.0:3000`, pas sur le host externe vu par le navigateur.

## Fix

Reconstruit la base URL depuis les headers `X-Forwarded-Host` / `X-Forwarded-Proto` que Traefik envoie automatiquement. En dev (accès direct sans proxy), retombe sur le `Host` header de la requête.

## Note

Cette PR est faite contre la version actuelle de main (article-only). Quand #127 sera mergée, le helper `getExternalBaseUrl` continuera de fonctionner — il faudra juste vérifier que les `NextResponse.redirect(...)` côté #127 utilisent aussi `getExternalBaseUrl(request)`.

## Test plan

- [ ] Cliquer « Aperçu » sur un article brouillon en prod → l'iframe charge bien `https://cultur-all.org/blog/<slug>?preview_token=...` et affiche le contenu
- [ ] Vérifier qu'aucune autre redirection Next.js n'est cassée

🤖 Generated with [Claude Code](https://claude.com/claude-code)