### PR TITLE
fix(home): revert background video to youtube.com domain

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -9,7 +9,7 @@ export default function Home() {
       <div className="landing">
         <div className="landing-video">
           <iframe
-            src={`https://www.youtube-nocookie.com/embed/${VIDEO_ID}?autoplay=1&mute=1&loop=1&playlist=${VIDEO_ID}&controls=0&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3&disablekb=1&fs=0&cc_load_policy=0`}
+            src={`https://www.youtube.com/embed/${VIDEO_ID}?autoplay=1&mute=1&loop=1&playlist=${VIDEO_ID}&controls=0&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3&disablekb=1&fs=0&cc_load_policy=0`}
             allow="autoplay; encrypted-media"
             title="Vidéo de fond Cultur'all"
           />


### PR DESCRIPTION
The youtube-nocookie.com variant introduced in 09a983f triggers
YouTube's anti-bot challenge ("Connectez-vous pour confirmer que
vous n'êtes pas un robot") on privacy-focused browsers like Brave,
which blocks the embed entirely on mobile.

Switch back to www.youtube.com while keeping the hardened URL
params (iv_load_policy, disablekb, fs, cc_load_policy) so we retain
the overlay cleanup from #116 without the anti-bot blockage.

https://claude.ai/code/session_01W5kNkcXNdPqyUoRyJzXyae