### PR TITLE
chore: upgrade Wagtail 6.3 → 7.4 LTS

### DIFF
--- a/backend/home/migrations/0003_seed_home_page.py
+++ b/backend/home/migrations/0003_seed_home_page.py
@@ -72,6 +72,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ("home", "0002_contactsubmission"),
         ("wagtailcore", "0094_alter_page_locale"),
+        ("wagtailsearch", "0010_add_text_fields"),
     ]
 
     operations = [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 Django>=5.2,<5.3
-wagtail>=6.3,<7.0
+wagtail>=7.4,<8.0
 django-taggit>=6.1,<7.0
 psycopg2-binary>=2.9,<3.0
 dj-database-url>=2.2,<3.0


### PR DESCRIPTION
## Summary

- Bumpe la contrainte Wagtail de `>=6.3,<7.0` vers `>=7.4,<8.0` (LTS)
- Ajoute `wagtailsearch.0010_add_text_fields` comme dépendance de `home.0003_seed_home_page` pour éviter une transaction avortée lors des migrations : le nouveau moteur de recherche `modelsearch` (introduit en 7.2) tente d'indexer les pages à chaque `save()`, ce qui échoue si la table `wagtailsearch_indexentry` n'existe pas encore

## Nouvelles dépendances transitives

Wagtail 7.4 introduit deux nouvelles dépendances directes (déjà résolues automatiquement par pip) :
- `modelsearch>=1.3` — nouveau moteur de recherche base de données
- `django-tasks>=0.9` — gestion des tâches en arrière-plan

## Test plan

- [x] `pip install wagtail>=7.4,<8.0 --dry-run` : aucun conflit de dépendances
- [x] `manage.py migrate` : 7 nouvelles migrations Wagtail appliquées sans erreur
- [x] Suite de tests : 90/90 passent
- [x] Admin Wagtail 7.4 : fonctionnel (autosave, nouvelle pagination, listings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)