### PR TITLE
feat(admin): ajouter raccourcis admin depuis le site public

### DIFF
--- a/backend/home/auth_views.py
+++ b/backend/home/auth_views.py
@@ -20,6 +20,7 @@ def auth_check(request):
 
     return JsonResponse({
         "authenticated": request.user.is_authenticated,
+        "is_admin": request.user.is_staff,
         "require_authentication": settings.require_authentication,
         "logo_url": logo_url,
     })

--- a/backend/home/tests/test_auth.py
+++ b/backend/home/tests/test_auth.py
@@ -14,13 +14,24 @@ class TestAuthCheck:
         assert resp.status_code == 200
         data = resp.json()
         assert data["authenticated"] is False
+        assert data["is_admin"] is False
         assert "require_authentication" in data
 
     def test_authenticated_user(self, client: Client, user, site_settings):
         client.force_login(user)
         resp = client.get(self.url)
         assert resp.status_code == 200
-        assert resp.json()["authenticated"] is True
+        data = resp.json()
+        assert data["authenticated"] is True
+        assert data["is_admin"] is False
+
+    def test_staff_user_is_admin(self, client: Client, user, site_settings):
+        user.is_staff = True
+        user.save()
+        client.force_login(user)
+        resp = client.get(self.url)
+        assert resp.status_code == 200
+        assert resp.json()["is_admin"] is True
 
     def test_reflects_site_setting(self, client: Client, site_settings):
         site_settings.require_authentication = False

--- a/frontend/app/blog/[slug]/page.tsx
+++ b/frontend/app/blog/[slug]/page.tsx
@@ -14,6 +14,7 @@ export default function ArticleDetailPage() {
 
   const [article, setArticle] = useState<Article | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     if (!params.slug) return;
@@ -41,6 +42,18 @@ export default function ArticleDetailPage() {
       .finally(() => setLoading(false));
     return () => controller.abort();
   }, [params.slug, previewToken]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`${API_URL}/api/auth/check/`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
+      .then((res) => res.json())
+      .then((data) => setIsAdmin(Boolean(data.is_admin)))
+      .catch(() => setIsAdmin(false));
+    return () => controller.abort();
+  }, []);
 
   if (loading) {
     return (
@@ -76,10 +89,20 @@ export default function ArticleDetailPage() {
         </div>
       )}
       <div className="article-detail-wrapper">
-        <Link href="/blog" className="article-detail__back">
-          <span className="article-detail__back-icon" aria-hidden="true">←</span>
-          <span>Blog</span>
-        </Link>
+        <div className="article-detail__actions">
+          <Link href="/blog" className="article-detail__back">
+            <span className="article-detail__back-icon" aria-hidden="true">←</span>
+            <span>Blog</span>
+          </Link>
+          {isAdmin && (
+            <a
+              href={`/admin/pages/${article.id}/edit/`}
+              className="article-detail__edit"
+            >
+              Modifier
+            </a>
+          )}
+        </div>
         <article className="article-detail">
           <h1>{article.title}</h1>
           {article.tags.length > 0 && (

--- a/frontend/app/components/Header.tsx
+++ b/frontend/app/components/Header.tsx
@@ -11,6 +11,7 @@ const SCROLL_THRESHOLD = 50;
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const [logoUrl, setLogoUrl] = useState<string | null>(null);
   const pathname = usePathname();
@@ -36,10 +37,12 @@ export default function Header() {
       .then((res) => res.json())
       .then((data) => {
         setAuthenticated(data.authenticated);
+        setIsAdmin(Boolean(data.is_admin));
         setLogoUrl(data.logo_url ?? null);
       })
       .catch(() => {
         setAuthenticated(false);
+        setIsAdmin(false);
         setLogoUrl(null);
       });
   }, [pathname]);
@@ -63,6 +66,7 @@ export default function Header() {
       credentials: 'include',
     });
     setAuthenticated(false);
+    setIsAdmin(false);
     router.push('/login');
     router.refresh();
   }
@@ -99,6 +103,15 @@ export default function Header() {
         <Link href="/blog" onClick={() => setMenuOpen(false)}>Blog</Link>
         <Link href="/a-propos" onClick={() => setMenuOpen(false)}>À propos</Link>
         <Link href="/contact" onClick={() => setMenuOpen(false)}>Contact</Link>
+        {isAdmin && (
+          <a
+            href="/admin/"
+            className="header-nav__admin"
+            onClick={() => setMenuOpen(false)}
+          >
+            Administration
+          </a>
+        )}
         {authenticated && (
           <button className="header-nav__link" onClick={handleLogout}>
             Déconnexion

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -81,6 +81,10 @@ body {
   opacity: 0.8;
 }
 
+.header-nav a.header-nav__admin {
+  color: #facc15;
+}
+
 /* Hamburger button — hidden on desktop, visible on mobile */
 .header-burger {
   display: none;
@@ -533,6 +537,38 @@ body {
 .project-detail__back:hover .project-detail__back-icon,
 .article-detail__back:hover .article-detail__back-icon {
   transform: translateX(-3px);
+}
+
+.project-detail__actions,
+.article-detail__actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.project-detail__edit,
+.article-detail__edit {
+  display: inline-flex;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: #facc15;
+  border: 1px solid #facc15;
+  border-radius: 2rem;
+  color: #000;
+  text-decoration: none;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.project-detail__edit:hover,
+.article-detail__edit:hover {
+  background: #fde047;
+  border-color: #fde047;
 }
 
 .project-detail__byline,

--- a/frontend/app/projets/[slug]/page.tsx
+++ b/frontend/app/projets/[slug]/page.tsx
@@ -21,6 +21,7 @@ export default function ProjectDetailPage() {
 
   const [project, setProject] = useState<Project | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
     if (!params.slug) return;
@@ -46,6 +47,18 @@ export default function ProjectDetailPage() {
       .finally(() => setLoading(false));
     return () => controller.abort();
   }, [params.slug, previewToken]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    fetch(`${API_URL}/api/auth/check/`, {
+      credentials: 'include',
+      signal: controller.signal,
+    })
+      .then((res) => res.json())
+      .then((data) => setIsAdmin(Boolean(data.is_admin)))
+      .catch(() => setIsAdmin(false));
+    return () => controller.abort();
+  }, []);
 
   if (loading) {
     return (
@@ -83,10 +96,20 @@ export default function ProjectDetailPage() {
         </div>
       )}
       <div className="project-detail-wrapper">
-        <Link href="/projets" className="project-detail__back">
-          <span className="project-detail__back-icon" aria-hidden="true">←</span>
-          <span>Projets</span>
-        </Link>
+        <div className="project-detail__actions">
+          <Link href="/projets" className="project-detail__back">
+            <span className="project-detail__back-icon" aria-hidden="true">←</span>
+            <span>Projets</span>
+          </Link>
+          {isAdmin && (
+            <a
+              href={`/admin/pages/${project.id}/edit/`}
+              className="project-detail__edit"
+            >
+              Modifier
+            </a>
+          )}
+        </div>
         <article className="project-detail">
         <h1>{project.title}</h1>
         {(project.tags.length > 0 || project.year || project.video_duration) && (


### PR DESCRIPTION
## Summary

- Permet aux administrateurs d'accéder rapidement au back-office Wagtail depuis le site public, sans avoir à manipuler l'URL.
- Boutons strictement réservés aux comptes `is_staff` ; aucun changement visible pour les visiteurs anonymes ou les utilisateurs non-admin.

Fixes #133

## Changes

- `backend/home/auth_views.py` — expose `is_admin` (= `request.user.is_staff`) dans la réponse de `/api/auth/check/`.
- `backend/home/tests/test_auth.py` — ajoute la couverture pour les trois cas (anonyme, user normal, staff).
- `frontend/app/components/Header.tsx` — affiche un item de menu « Administration » vers `/admin/` quand `is_admin`.
- `frontend/app/projets/[slug]/page.tsx` & `frontend/app/blog/[slug]/page.tsx` — bouton « Modifier » (pill jaune) à côté du bouton retour, qui pointe vers `/admin/pages/<id>/edit/` (les projets et articles sont des Wagtail Pages).
- `frontend/app/globals.css` — styles pour le pill jaune et la couleur du lien admin.

## How it was tested

- [x] `pytest -v` côté backend (106 tests, 11 dans `test_auth.py`)
- [x] `tsc --noEmit` côté frontend
- [ ] Vérification manuelle dans le navigateur **non effectuée** : le stack docker preview de la session est bind-monté sur un autre worktree, je n'ai pas pu lancer cette branche en preview. À tester côté reviewer : (a) menu admin visible/invisible selon `is_staff`, (b) pill « Modifier » présente sur projet/article uniquement pour admin, (c) clic mène bien à l'écran d'édition Wagtail.

## Risks and rollout

- Risque faible. Le champ `is_admin` ajouté à la réponse `auth_check` est purement additif, rétro-compatible.
- Aucun changement de comportement pour les utilisateurs non-admin (anonymes ou connectés).
- Le lien `/admin/` est servi par Django via Nginx → `<a>` natif (pas de Next `Link`), donc full reload au clic, c'est bien le comportement attendu.

---

Closes #133