### PR TITLE
chore(deploy): durcir le pipeline prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -7,6 +7,28 @@ name: Deploy to Production
 # d'autres apps via le network défini par traefik_default). Les services
 # django, nextjs et minio s'enregistrent auprès de Traefik via labels.
 #
+# Ordre de déploiement (durci suite à l'incident du 2026-05-06) :
+#   1. git pull + docker login
+#   2. compose pull django nextjs (récupère les nouvelles images)
+#   3. compose up -d postgres minio (deps DB + storage seules, sans toucher
+#      django/nextjs encore — les conteneurs courants continuent de servir)
+#   4. Gate fail-fast sur l'historique des migrations via `showmigrations`
+#      (plante avec InconsistentMigrationHistory sans muter la DB ; lancé
+#      via `compose run --rm` sur la NOUVELLE image Django)
+#   5. Apply migrations (`migrate --noinput`) via `compose run --rm`
+#   6. collectstatic via `compose run --rm` AVANT de démarrer le nouveau
+#      gunicorn — sans ça gunicorn cache l'ancien manifest staticfiles.json
+#      en RAM et sert un HTML pointant vers des hashes ensuite régénérés,
+#      ce qui casse l'admin Wagtail (500 sur tous les assets).
+#   7. compose up -d --force-recreate django nextjs (swap final, gunicorn
+#      démarre avec le manifest à jour)
+#   8. update_index (best-effort) + prune images
+#
+# Note volumes : `compose run --rm django` hérite par défaut des volumes
+# du service `django` (static_files:/app/staticfiles, media_files:/app/media),
+# donc les `migrate` / `collectstatic` lancés via `run` écrivent dans les
+# mêmes volumes que ceux montés par `up -d`.
+#
 # Déclenchements :
 #   - Manuel via UI ou `gh workflow run`
 #   - Automatique : depuis build-images.yml (workflow_dispatch avec image_tag)
@@ -58,18 +80,38 @@ jobs:
             echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io \
               -u ${{ secrets.GHCR_USERNAME }} --password-stdin
 
-            echo "==> Pulling pre-built images..."
+            echo "==> Pulling pre-built images (django, nextjs)..."
             $COMPOSE_CMD pull django nextjs
 
-            echo "==> Restarting services with new images..."
-            # nginx est désactivé en prod (Traefik fait le reverse proxy)
-            $COMPOSE_CMD up -d --force-recreate --no-build django nextjs minio postgres
+            echo "==> Starting deps only (postgres, minio)..."
+            # On démarre/maintient uniquement les deps. django et nextjs
+            # courants continuent de servir le trafic pendant le gate
+            # migrations. Le swap final se fait à l'étape 7.
+            $COMPOSE_CMD up -d postgres minio
+
+            echo "==> Gate : checking migration history consistency..."
+            # `showmigrations` lit django_migrations + le graphe et lève
+            # InconsistentMigrationHistory si une migration appliquée a
+            # une dépendance non appliquée (cas de l'incident 2026-05-06).
+            # Lancé via `run --rm` sur la NOUVELLE image (donc avec le
+            # nouveau code Wagtail/apps) sans rien muter en DB. Si ce
+            # check passe, on peut faire confiance au plan migrate ensuite.
+            $COMPOSE_CMD run --rm django python manage.py showmigrations
 
             echo "==> Running Django/Wagtail migrations..."
-            $COMPOSE_CMD exec -T django python manage.py migrate --noinput
+            $COMPOSE_CMD run --rm django python manage.py migrate --noinput
 
-            echo "==> Collecting static files..."
-            $COMPOSE_CMD exec -T django python manage.py collectstatic --noinput
+            echo "==> Collecting static files (BEFORE recreating django)..."
+            # Doit tourner AVANT `up -d --force-recreate django` : gunicorn
+            # cache staticfiles.json en RAM au démarrage, donc régénérer
+            # le manifest après le start sert un HTML pointant vers d'anciens
+            # hashes (admin Wagtail 500 sur tous ses assets).
+            $COMPOSE_CMD run --rm django python manage.py collectstatic --noinput
+
+            echo "==> Recreating django + nextjs with new images..."
+            # nginx est désactivé en prod (Traefik fait le reverse proxy).
+            # postgres et minio ont déjà été démarrés à l'étape 3.
+            $COMPOSE_CMD up -d --force-recreate --no-build django nextjs
 
             echo "==> Updating Wagtail search index..."
             $COMPOSE_CMD exec -T django python manage.py update_index || true

--- a/backend/blog/migrations/0003_migrate_articles_to_pages.py
+++ b/backend/blog/migrations/0003_migrate_articles_to_pages.py
@@ -16,6 +16,14 @@ from django.utils.text import slugify
 
 
 def migrate_articles_to_pages(apps, schema_editor):
+    # Idempotence : si la table source a déjà été droppée par la migration
+    # successeur (0004), on no-op pour éviter un crash quand la chaîne est
+    # rejouée sur une DB déjà avancée (ex : `migrate --fake` puis `migrate`
+    # depuis zéro après un reset, ou cascade après InconsistentMigrationHistory).
+    from django.db import connection
+    if "blog_article" not in connection.introspection.table_names():
+        return
+
     Article = apps.get_model("blog", "Article")
     ArticleTag = apps.get_model("blog", "ArticleTag")
 

--- a/backend/projects/migrations/0007_migrate_projects_to_pages.py
+++ b/backend/projects/migrations/0007_migrate_projects_to_pages.py
@@ -16,6 +16,14 @@ from django.utils.text import slugify
 
 
 def migrate_projects_to_pages(apps, schema_editor):
+    # Idempotence : si la table source a déjà été droppée par la migration
+    # successeur (0008), on no-op pour éviter un crash quand la chaîne est
+    # rejouée sur une DB déjà avancée (ex : `migrate --fake` puis `migrate`
+    # depuis zéro après un reset, ou cascade après InconsistentMigrationHistory).
+    from django.db import connection
+    if "projects_project" not in connection.introspection.table_names():
+        return
+
     Project = apps.get_model("projects", "Project")
     ProjectTag = apps.get_model("projects", "ProjectTag")
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 Django>=5.2,<5.3
-wagtail>=6.3,<7.0
+wagtail==6.4.2
 django-taggit>=6.1,<7.0
 psycopg2-binary>=2.9,<3.0
 dj-database-url>=2.2,<3.0


### PR DESCRIPTION
Closes #135

## Contexte

Suite à l'incident de déploiement du 2026-05-06 (cascade : upgrade Wagtail silencieux → `InconsistentMigrationHistory` → data migrations qui plantent → admin Wagtail 500 sur ses assets parce que collectstatic tournait après le démarrage de gunicorn).

## Les 3 fixes

### 1. Réordonnancement de `.github/workflows/deploy-prod.yml`

L'ordre des étapes était `up -d --force-recreate django` avant `migrate` et `collectstatic`, ce qui faisait servir par gunicorn un `staticfiles.json` obsolète caché en RAM. Nouvel ordre :

1. `git pull` + `docker login`
2. `compose pull django nextjs`
3. `compose up -d postgres minio` (deps seules)
4. **Gate fail-fast** : `compose run --rm django python manage.py showmigrations` → plante avec `InconsistentMigrationHistory` SANS muter la DB si l'historique est cassé. Choix de `showmigrations` plutôt que `migrate --check --plan` parce que ce dernier sort en code 1 dès qu'il y a une migration en attente (= cas nominal du déploiement), ce qui empêche de distinguer "incohérence" de "migrations à appliquer". `showmigrations` lit le graphe et lève `InconsistentMigrationHistory` sans rien appliquer, c'est strictement le check qu'on veut.
5. `compose run --rm django python manage.py migrate --noinput`
6. `compose run --rm django python manage.py collectstatic --noinput` (AVANT le swap)
7. `compose up -d --force-recreate django nextjs` (swap final, gunicorn boot avec le manifest à jour)
8. `update_index || true` + `docker image prune`

Les `compose run --rm` héritent des volumes du service `django` (`static_files`, `media_files`), donc collectstatic écrit bien dans le volume monté ensuite par `up -d`.

### 2. Pin de Wagtail à `6.4.2` dans `backend/requirements.txt`

Avant : `wagtail>=6.3,<7.0`. Maintenant : `wagtail==6.4.2` (dernière 6.x stable au moment du PR).

**Comment bumper proprement plus tard** :
1. Modifier la version dans `backend/requirements.txt`
2. Trigger le workflow `build-images.yml` pour rebuild les images
3. Tester sur preprod (déploiement complet + smoke admin Wagtail)
4. Merger sur `main` puis déployer en prod

### 3. Idempotence des data migrations

`backend/blog/migrations/0003_migrate_articles_to_pages.py` et `backend/projects/migrations/0007_migrate_projects_to_pages.py` faisaient `Article.objects.all()` / `Project.objects.all()` AVANT leur check d'idempotence sur les Pages cibles, ce qui crashait quand les tables source avaient déjà été droppées par leurs successeurs `0004` / `0008`.

Ajout d'un early-return en début de fonction :

```python
from django.db import connection
if "blog_article" not in connection.introspection.table_names():
    return
```

(idem `projects_project` pour la migration projects).

## Test plan

A valider sur preprod AVANT merge :

- [ ] Le workflow `deploy-prod.yml` se parse sans erreur côté GitHub Actions (yaml syntax)
- [ ] Le gate `showmigrations` s'exécute et n'écrit rien en DB (vérifier les logs `==> Gate :`)
- [ ] `migrate --noinput` tourne sans crash sur la chaîne complète, y compris quand `blog_article` / `projects_project` n'existent plus
- [ ] `collectstatic --noinput` tourne AVANT `up -d --force-recreate django` (vérifier l'ordre des `==>` dans les logs)
- [ ] Après déploiement, l'admin Wagtail charge ses assets (CSS/JS) sans 500 — vérifier `https://culturall-website.nickorp.com/admin/`
- [ ] `pip install -r backend/requirements.txt` installe bien Wagtail `6.4.2` (pas `7.x`)
- [ ] Faire un déploiement complet de bout en bout sur preprod et vérifier la home + admin

## Version Wagtail choisie

`wagtail==6.4.2` (dernière 6.x stable au 2026-05-06).