### PR TITLE
fix(slug): forcer les slugs ASCII pour éviter les 404 sur l'API

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -116,6 +116,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 WAGTAIL_SITE_NAME = "culturall-website"
 WAGTAILADMIN_BASE_URL = os.environ.get("WAGTAILADMIN_BASE_URL", "http://localhost:8000")
 WAGTAILDOCS_EXTENSIONS = ["csv", "docx", "key", "odt", "pdf", "pptx", "rtf", "txt", "xlsx", "zip"]
+# Les routes API détail utilisent le converter Django `<slug:>` qui ne matche
+# que `[-a-zA-Z0-9_]+`. Sans ce flag, un titre avec accent (ex. « éducatifs »)
+# génère un slug unicode inaccessible côté API → 404. Cf. issue #138.
+WAGTAIL_ALLOW_UNICODE_SLUGS = False
 
 # ─── Headless Preview ──────────────────────────────────────────
 _FRONTEND_URL = os.environ.get("FRONTEND_URL", "http://localhost:3000")


### PR DESCRIPTION
## Summary
- Désactive `WAGTAIL_ALLOW_UNICODE_SLUGS` (par défaut `True` dans Wagtail) pour que tous les nouveaux slugs auto-générés soient ASCII.
- Aligne la génération de slug Wagtail sur le converter Django `<slug:slug>` (`[-a-zA-Z0-9_]+`) utilisé par les routes API détail (articles, projets, pages statiques).
- Évite les 404 silencieux sur tout contenu dont le titre contient un caractère accentué (ex. `Kajou – Diffusion de contenus éducatifs et culturels hors ligne`).

Closes #138

## Test plan
- [ ] Dans l'admin Wagtail, créer un nouvel article avec un titre contenant des accents (ex. `Test des accents éducatifs`) et vérifier que le slug auto-généré ne contient que de l'ASCII (`test-des-accents-educatifs`).
- [ ] Publier l'article et vérifier que `/api/blog/articles/<slug>/` répond 200.
- [ ] Idem pour un `ProjectPage` via `/api/projects/<slug>/` et une `StaticPage` via `/api/pages/<slug>/`.
- [ ] Lancer la suite de tests backend (`pytest backend/`) — la fix ne devrait casser aucun test existant (les fixtures utilisent déjà des slugs ASCII).

## Follow-up manuel
Les pages **déjà publiées** avec un slug accentué resteront cassées tant qu'on ne les renomme pas dans l'admin (ou via une data migration ponctuelle si la liste devient longue). À traiter en dehors de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)