### PR TITLE
data: JSON d'import des 97 projets Cultur'All

### DIFF
--- a/projects_import.json
+++ b/projects_import.json
@@ -1,0 +1,1266 @@
+[
+  {
+    "title": "RUMBLE STATION 4, Release Party De DIGITALDA \"Deh Pon Di Low\" le 27/09/24",
+    "youtube_url": "https://www.youtube.com/watch?v=rWycGqL6HzA",
+    "description": "Programmation 100% féminine:\n- Feminine HI-FI from Brasil - Marina P - Amazones Shot - Sonorisé par Livication Corner",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "32 secondes",
+    "tags": [
+      "réel",
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "rWycGqL6HzA"
+  },
+  {
+    "title": "Digitalda - Deh Pon Di Low (Official Music Video)",
+    "youtube_url": "https://www.youtube.com/watch?v=U2xHCISAxaE",
+    "description": "Embarquez dans le Sound-System Mobile de Digitalda pour une aventure à travers des mondes oniriques, baignés dans des rythmes enivrants et la sauce Bicky. Ces univers sont peuplés de créatures faites de câbles, d’accessoires musicaux et de fricadelles volantes !\nLe clip \"Deh Pon Di Low\" est enfin là, rendant hommage à Digitalda, qui continue d’inonder la terre et le ciel de sa créativité et de sa musicalité sans limites. ð¶✨\nð Deh Pon Di Low est aussi dispo en Vinyle et en Streaming ð https://distrokid.com/hyperfollow/digitalda/deh-pon-di-low",
+    "credits": "ð¥ Animation : Simon Takerkart / Studio Colora ðµ Compositeur : Cisko ð¬ Producteur : Lucas Takerkart pour Cultur’all ð️ Producteur exécutif : Louis Domagala ð¥ Co-producteur : Rémi Takerkart ð Mix : Cisko @Guardian House ð Master : Sébastien Houot @Wise Studio",
+    "year": "2024",
+    "video_duration": "3 minutes 10 secondes",
+    "tags": [
+      "clip"
+    ],
+    "featured": false,
+    "_video_id": "U2xHCISAxaE"
+  },
+  {
+    "title": "27/09 @Flow à Lille. Plateau 100% féminin Féminine Hi-Fi, Marina P Amazones Shot, Livication Corner",
+    "youtube_url": "https://www.youtube.com/watch?v=P9Urp7_JFgo",
+    "description": "",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "27 secondes",
+    "tags": [
+      "réel",
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "P9Urp7_JFgo"
+  },
+  {
+    "title": "Art Urbain et Palais des Beaux-Arts de Lille #graffiti #art",
+    "youtube_url": "https://www.youtube.com/watch?v=coQhnSCZjDE",
+    "description": "Teaser créé à l'occasion des 10 ans de la Biennale Internationale d’Art Mural.\nTableau \"Joseph et la fille de Peutiphar\" de Leonello Spada reproduit en fresque à Lille.",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "36 secondes",
+    "tags": [
+      "réel",
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "coQhnSCZjDE"
+  },
+  {
+    "title": "Art Pictural et Engagements Politiques - Conférence de Jean Faucheur et Taqi Spateen @flowlille7372",
+    "youtube_url": "https://www.youtube.com/watch?v=aXeM3AABS70",
+    "description": "Dans le cadre de la Biennale Internationale d’Art Mural, Le collectif Renart invite les artistes Jean Faucheur (Président de la Fédération de l'Art Urbain) et Taqi Spateen pour une table ronde autour du thème « Arts et engagements politiques ». A priori beaucoup de choses les oppose. Jean Faucheur est né en France en 1956, a investi les rues parisiennes dans les années 1980 mais c’est d’abord le travail en atelier qui le définit. Taqi Spateen est, lui, né en 1991 en Palestine et s’exprime avant tout dans les espaces publics d’ici et d’ailleurs. Pour autant, chacun à leur manière, leurs pratiques artistiques sont entrées en résonance avec certaines luttes. Entre mise en image de conflits, détournement publicitaire, dénonciation de mécanisme de domination ou militantisme institutionnel, comment s’articule travail créatif et engagement politique ? L’un précède t’il l’autre ? L’un est-il mis au service de l’autre ? Au contraire, peut-être est-il vain de chercher la linéarité d’un parcours de vie plus complexe dans lequel productions artistiques et engagements politiques s’enchevêtrent plus qu’ils ne se succèdent. Quid de l’œuf créatif ou de la poule militante…",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "1 heures 24 minutes 24 secondes",
+    "tags": [
+      "captation conférence"
+    ],
+    "featured": false,
+    "_video_id": "aXeM3AABS70"
+  },
+  {
+    "title": "Le Bestiaire articulé - Défilé marionnettique. Projet d'action culturel",
+    "youtube_url": "https://www.youtube.com/watch?v=EueDX0N7IPQ",
+    "description": "Projet d'action culturel\nLe Bestiaire articulé est un défilé haute couture marionnettique pour espace public, en étroite collaboration avec les habitants. Avec ce public, nous imaginons un projet allant de la création textile autour de la thématique du Bestiaire à la présentation des œuvres sous forme d’un défilé-spectacle.\nCette action se mène en plusieurs étapes de travail :\nConception de robes haute-couture et marionnettes Stage théâtre et occupation de l'espace urbain en portant les vêtements marionnettiques créés Défilé du Bestiaire Articulé en salle ou dans l'espace urbain, avec 2 musiciens et un.e présentateur.rice.\nAssociation Institut Brut de Singularité http://institutbrut.e-monsite.com/\nLiens Interview france 3 region: https://vimeo.com/253247622\nMédia https://www.themaa-marionnettes.com/wp-content/uploads/2023/10/manip75_web.pdf\nMARIONNETTES ET MÉDIATIONS De fil et d’os, « Le bestiaire articulé » : coudre ensemble Avec Françoise et les couturières de l’association « Fil, Aiguille et Cie »",
+    "credits": "Conception et mise en scène : Vaïssa Favereau Créé en collaboration avec Capucine Desoomer Créé en collaboration et interprété par Julie Canadas Création musicale : Simon Demouveaux et Bastien Charlery Coproduction : Cie de Fil et d'Os Porté par : Institut Brut de Singularité Réalisation et captation : Cultur'all Prise d'image à la Fabrique Théâtrale - Culture Commune - Loos-en-Gohelle",
+    "year": "2024",
+    "video_duration": "4 minutes 9 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "EueDX0N7IPQ"
+  },
+  {
+    "title": "Taqi Spateen à Lille",
+    "youtube_url": "https://www.youtube.com/watch?v=yLuvpOMHz_M",
+    "description": "L'artiste palestinien @taqi_spateen a été invité en mai 2023 par le @collectif_renart pour peindre cette fresque rue Montesquieu à Lille. Dans cette vidéo il nous explique le sens de sa peinture. Retrouvez l'ensemble de son interview sur la chaîne youtube de @culturall1 dans le film consacré aux fresques lilloises réalisées pour les 10 ans de la BIAM.",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "55 secondes",
+    "tags": [
+      "réel"
+    ],
+    "featured": false,
+    "_video_id": "yLuvpOMHz_M"
+  },
+  {
+    "title": "XPLORATION(S), Outras histórias de graffiti, Géograffiti 2 ST PT/BR",
+    "youtube_url": "https://www.youtube.com/watch?v=6or3pWx0FNc",
+    "description": "XPLORATION(S),\nOutras historias de graffiti , realisado por Lucas Takerkart\nEste filme é movido pela paixão de explorar a cidade de forma diferente. Os guias são grafiteiros do norte da França. Através destas histórias de graffiti, pontuadas pelo duplo H do Hip-Hop, encontramos pedaços de história com H maiúsculo.\nTraducao portuguesea/brasileira por Lorena VITA FERREIRA\n#graffiti #rap #pixo pixação",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "36 minutes 59 secondes",
+    "tags": [
+      "documentaire"
+    ],
+    "featured": false,
+    "_video_id": "6or3pWx0FNc"
+  },
+  {
+    "title": "XPLORATION(S), D'autres Histoires de Graff, Géograffiti 2 ST ENGL",
+    "youtube_url": "https://www.youtube.com/watch?v=knYoliD9HFk",
+    "description": "Traduction English par Lorena VITA FERREIRA\nXPLORATION(S),\nD'autres Histoires de Graff, réalisé par Lucas Takerkart\nCe film est animé par la passion d'explorer la ville autrement. Les guides sont les graffeurs du nord de la France. A travers ces histoires de graffitis, rythmées par le double H du Hip-Hop, on retrouve des bribes de l'histoire avec un grand H.",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "36 minutes 59 secondes",
+    "tags": [
+      "documentaire"
+    ],
+    "featured": false,
+    "_video_id": "knYoliD9HFk"
+  },
+  {
+    "title": "XPLORATION(S), D'autres Histoires de Graff, Géograffiti 2 ST FR",
+    "youtube_url": "https://www.youtube.com/watch?v=w0n5Gw6_3cQ",
+    "description": "XPLORATION(S),\nD'autres Histoires de Graff, réalisé par\nLucas Takerkart\nCe film est animé par la passion d'explorer la ville autrement. Les guides sont les graffeurs du nord de la France. A travers ces histoires de graffitis, rythmées par le double H du Hip-Hop, on retrouve des bribes de l'histoire avec un grand H.",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "36 minutes 59 secondes",
+    "tags": [
+      "documentaire"
+    ],
+    "featured": false,
+    "_video_id": "w0n5Gw6_3cQ"
+  },
+  {
+    "title": "YWILL - Le Fantôme de l'Opéra #graffiti #lille #rap #tag",
+    "youtube_url": "https://www.youtube.com/watch?v=DbWdiTuGqE4",
+    "description": "Xtrait d'Xploration(S) - D'autres Visages du Nord - Géograffiti2 -\nRéalisé par Lucas Takerkart\nÉcrit par YWILL Composé par GreenFish Cadrage par Jonathan Oliveira et Alpha Bandit Styliste: Mariem LÔ,\nAvec YWILL, Lena Cayrade et T-JAH",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "24 secondes",
+    "tags": [
+      "clip"
+    ],
+    "featured": false,
+    "_video_id": "DbWdiTuGqE4"
+  },
+  {
+    "title": "YWILL- Le Fantôme de l'Opéra (version longue)",
+    "youtube_url": "https://www.youtube.com/watch?v=zbZa5K7cd4I",
+    "description": "Xtrait d'Xploration(S) - D'autres Visages du Nord - Géograffiti2 -\nÉcrit par @YWillLaJonctionOfficiel\nComposé par @Greenfinch Réalisé par Lucas Takerkart Montage Thomas Dadoun @projetps\nCadrage par Jonathan Oliveira et Alpha Bandit Styliste: Mariem LÔ,\nAvec YWILL, Lena Cayrade et T-JAH\nRemerciements Au Flow Lille et l'Opéra de Lille",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "3 minutes 16 secondes",
+    "tags": [
+      "clip"
+    ],
+    "featured": false,
+    "_video_id": "zbZa5K7cd4I"
+  },
+  {
+    "title": "Guilty - La Base",
+    "youtube_url": "https://www.youtube.com/watch?v=Ep-_6_to1mk",
+    "description": "Xtrait d'Xploration(S) - D'autres Visages du Nord - Géograffiti2 - réalisé par Lucas Takerkart bientôt sur cette chaîne. Images additionnelles : Jonathan Oliveira Fxs : Cédric VC\nGuilty - La Base dispo sur la 'Little Mixtape Vol.2' prochainement sur grizzmine.com Instru - Fatale Clique by Zakaprod Beatmaker Scratch - Dj Fidjay",
+    "credits": "",
+    "year": "2024",
+    "video_duration": "2 minutes 23 secondes",
+    "tags": [
+      "clip"
+    ],
+    "featured": false,
+    "_video_id": "Ep-_6_to1mk"
+  },
+  {
+    "title": "Dame Cartouche - Cultur'All archives",
+    "youtube_url": "https://www.youtube.com/watch?v=V9_wxZQmLGU",
+    "description": "Une Zad au milieu de Lille entre deux confinements",
+    "credits": "Musique : MayI",
+    "year": "2023",
+    "video_duration": "1 minutes 25 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "V9_wxZQmLGU"
+  },
+  {
+    "title": "Digitalda et 102 - Grande Transe  Shatta Dancehall - 04/112022",
+    "youtube_url": "https://www.youtube.com/watch?v=fFiwwzww-is",
+    "description": "La grande transe Shatta Dancehall c'était ça!\nOrganisée par @digitalda7083 avec 102 et un cours de dancehall donné par Maymouna Produit par Cultur'All\nOn remet ça le 2 décembre avec deux live band : Mr Aya And The Classics ainsi que Macka B avec le Roots Ragga Band, Dj Sweetback, 102 et Syndie pour une initiation Soca. C'est à 19h30 à la Salle des fêtes de Lille Fives. PAF : 5/3€",
+    "credits": "@flowlille7372 Open Mic strictly ladies. C'était le feeeuuuu!!! Images : Alpha Bandit Montage : Cultur'All",
+    "year": "2023",
+    "video_duration": "2 minutes 27 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "fFiwwzww-is"
+  },
+  {
+    "title": "Macka B  le 2/12/2023 à Lille",
+    "youtube_url": "https://www.youtube.com/watch?v=e_cXSyF0__I",
+    "description": "Avec Macka B et le Roots Ragga Band, Mr Aya and the Classics, DJ Sweetback, DJ 102, initiation de danse Soca par Syndie. 2/12/2023, Salle des fêtes de Lille Fives, 19h30.\nLaissez-vous emporter dans une danse joyeuse et contagieuse, où le rythme devient le langage universel de la nuit. La programmation vous invite à célébrer la musique jamaïcaine. Ce bal à Fives aux sonorités Reggae Dancehall démarrera avec les locaux Mr Aya & the Classics sur des rythmes éclectiques, passant de ballades roots à la soca, puis par le dancehall ou le raggamuffin à l’ancienne. Suivra Macka B, artiste né en Angleterre de parents jamaïcains immigrés. Il s’est mis à écrire ses textes après un voyage en Jamaïque. Riche et diverse, forte de mélodies entraînantes et de paroles engagées, sa musique fait vibrer les âmes depuis près de quarante ans. En point final : 102, Djette issue des sound system. Précédé d’un warm up\npar Dj Sweetback et d’une initiation à la Soca par Syndie.\nRestauration typique jamaïquaine.\nTarifs entrées: 3 et 5€\nEn amont du bal : conférence sur le Dancehall par Sir James accompagné au mix de deux vétérans des Sound System du Nord de la France : Ras.T et Selecta D-Day le jeudi 30 novembre au café Le Musical à 18h30!!!",
+    "credits": "",
+    "year": "2023",
+    "video_duration": "45 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "e_cXSyF0__I"
+  },
+  {
+    "title": "Le film des 10 ans de la BIAM est en ligne",
+    "youtube_url": "https://www.youtube.com/watch?v=zd8CQZof7d0",
+    "description": "",
+    "credits": "",
+    "year": "2023",
+    "video_duration": "16 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "zd8CQZof7d0"
+  },
+  {
+    "title": "10 ans de la Biennale Internationale d'Art Mural @ Lille 4k",
+    "youtube_url": "https://www.youtube.com/watch?v=HlRccpwcAdQ",
+    "description": "Pour les 10 ans de la BIAM organisée par le Collectif Renart, Cultur'All a suivi la réalisation des fresques lilloises de cette édition. Vous y retrouverez les peintres du Collectif Tzouri (Maroc), les old timers du graffiti Rosy One et Ruff (Suisse), le calligraphe Zepha de Toulouse et son 'Jagua' qui permet de faire des tatouages éphémères. Il y a aussi Taqi Spateen de Palestine et Andrea Ravo Mattoni (Italie) qui a reproduit sur une façade de maison un tableau du Musée de Beaux Arts de Lille.\nMusiques : @alseptseptsept",
+    "credits": "Avec : Rosy One, Ruff One, Andrea Ravo Mattoni, Taqi Spateen, Vincent Abadie Hafez Aka Zepha, Pi80, Dany One, Oakoak",
+    "year": "2023",
+    "video_duration": "12 minutes 57 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "HlRccpwcAdQ"
+  },
+  {
+    "title": "Clip dispo ''Deeply Better'' Chill Squad Brothers feat Ishmel McAnuff",
+    "youtube_url": "https://www.youtube.com/watch?v=3MVTJsw_oOI",
+    "description": "",
+    "credits": "",
+    "year": "2023",
+    "video_duration": "30 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "3MVTJsw_oOI"
+  },
+  {
+    "title": "KaAas   Tu sais 2/3, Terroir Prod, juin 2012",
+    "youtube_url": "https://www.youtube.com/watch?v=OknfPMRUB3U",
+    "description": "Terroir Prod, juin 2012\nLien complet: https://youtu.be/ooAl1QOtnT0?si=dqoWYWY79hhnNUT4\nLe répondeur Manon Théo Inisan",
+    "credits": "Réalisation: Ismail Assalih Cadrage et Post-production: Thomas Dadoun / http://www.loeil-et-la-lune.fr\nAvec: Marc-Antoine Martel Léa Claverie\nRemerciements: Le Oinjénieur Jim Karl Armel",
+    "year": "2023",
+    "video_duration": "40 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "OknfPMRUB3U"
+  },
+  {
+    "title": "KaAas  - Tu Sais (1/3) retour sur nos archives Terroir Prod, juin 2012",
+    "youtube_url": "https://www.youtube.com/watch?v=Ldnc0gX0kDY",
+    "description": "Terroir Prod, juin 2012\nLien complet: https://youtu.be/ooAl1QOtnT0?si=dqoWYWY79hhnNUT4\nLe répondeur Manon Théo Inisan",
+    "credits": "Réalisation: Ismail Assalih Cadrage et Post-production: Thomas Dadoun / http://www.loeil-et-la-lune.fr\nAvec: Marc-Antoine Martel Léa Claverie\nRemerciements: Le Oinjénieur Jim Karl Armel",
+    "year": "2023",
+    "video_duration": "39 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "Ldnc0gX0kDY"
+  },
+  {
+    "title": "Cultur'All Demo reel 2023",
+    "youtube_url": "https://www.youtube.com/watch?v=8IszrSxq6W0",
+    "description": "Pour fêter nos 3000 abonnés sur la chaîne, on vous sort notre nouveau démo reel! C'est une compilation d'images que nous avons tourné ces trois dernières années et on s'est amusé (un peu) à tout mélanger dans un montage.\nNous sommes un collectif nordiste œuvrant à la valorisation des cultures populaire par l'audiovisuel et l'évènementiel. L'année dernière la petite soeur Cultur'All Massalia (Marseille) est née\npour réaliser encore plus de beaux évènements et de vidéos. Dans la lignée 2023 va être une très belle année\nMusique du Demo Reel :\nAl 777\nEQUIPE CULTUR'ALL (Lille)\n- Louis Domagala, président\n- Nicolas Declerck conseil d'administration - Martin Minart conseil d'administration\nRéalisations, images et montages: - Lucas Takerkart\nhttps://www.linkedin.com/in/lucas-takerkart-82b97bb4 - Jonathan Oliveira\nhttps://www.linkedin.com/in/jonathan-oliveira-94162820a/ - Justine Lescornez\n@alpha_bandit (instagram) - Armel Domagala\nEQUIPE CULTUR'ALL MASSALIA (Marseille) - Elias Lecocq - Benjamin Potet - Djamel Reffes\nCONTACTER CULTUR'ALL - Mail : com@cultur-all.org - Instagram : @culturall1 - Facebook : https://www.facebook.com/assoculturall - linkedin : https://www.linkedin.com/company/cultur'all/\nMerci à toustes, artistes, institutions et autres de votre confiance, participation et contribution:\n- La Condition Publique\n- Le Flow Lille - La mairie de Lille - Léa Boos - Rabah Asma - Montparnasse Musique - Aziz Konkrite, Sidiba sound system - Estelle Carlier et Amety - Raï Roots, Djamel Reffes.... - Orchestre national de Barbes - Fokn Bois - Kerozen - Tracy Dessa ( avec la cave aux poètes) - Kamini - Digitalda - Prince, La Jonction - Dj Stamiff -Mando Mcd - Lena Cayrad - Juliana Oliveira a.k.a. Buga - Lô Création - Midos Ladowz - Hospice Comtesse\n- Balao Mc - Palais Rihour - Kekro - Musée des\nBeaux Arts - Ywill , La Jonction - Opéra de Lille - Attacafa - Rajaa, Rajaa danse - Astree - Rana Gorgani - Bahore, Yosra Mojtahedi, Ana Elena Tejera - Clément Basset - Collectif Renard , BIAM - Kat et Action - Marko 93 - Twoone - Xtazia QDLZ ECF - Boks et Scar, DNK - Astro - Robert Montgomery - Magda Sayeg - Maya Hayuk - David Bruce - Breeze Yoko - Sephora\n- Samione\n- Charlotte Marette",
+    "credits": "",
+    "year": "2023",
+    "video_duration": "2 minutes 27 secondes",
+    "tags": [
+      "demo reel"
+    ],
+    "featured": false,
+    "_video_id": "8IszrSxq6W0"
+  },
+  {
+    "title": "BRAVES Lille 2023 concert de soutien aux grévistes au Flow",
+    "youtube_url": "https://www.youtube.com/watch?v=KXqYELuDeBs",
+    "description": "Concert de soutien aux grévistes contre la réforme des retraites. Organisé par La Familiale, Zéro Vice City, la compagnie Trous de Mémoires et le Flow\n\"On ne lâchera pas l'affaire, ce soir on prouve que le rap est encore contestataire.\" (Ywill - La Jonction)",
+    "credits": "Musique: Ben PLG Images: Louis Domagala, Clara Yvard, Jonathan Oliveira Réalisation : Cultur'All",
+    "year": "2023",
+    "video_duration": "3 minutes 3 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "KXqYELuDeBs"
+  },
+  {
+    "title": "Film - La Biennale Internationale d'Art Mural 2021",
+    "youtube_url": "https://www.youtube.com/watch?v=4i2jIkDhcE0",
+    "description": "La Biennale Internationale d'Art Mural 6 organisée par le Collectif Renart va bientôt commencer. C'est l'occasion de partager avec vous le film de la dernière édition réalisé par Lucas Takerkart.\nRouge Hartley (Allemagne) Lor-K (France) Marko93 (France) TWOONE (Japon) LEM (Tourcoing) Jameel Subay (Yémen) Kat & Action (France) San Momo (lille) Haute Bouture Astro (France) Jaune (Belgique) David Bruce (France) Murad Subay (Yémen) Benjamin Kluk(Roubaix)\nMUSIQUE\nOURS SAMPLUS #graffiti#artmural#streetartlille",
+    "credits": "Avec :",
+    "year": "2023",
+    "video_duration": "11 minutes 26 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "4i2jIkDhcE0"
+  },
+  {
+    "title": "On sort le Film de la dernière BIAM ce soir!!!",
+    "youtube_url": "https://www.youtube.com/watch?v=52UB4yx83ME",
+    "description": "",
+    "credits": "",
+    "year": "2023",
+    "video_duration": "43 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "52UB4yx83ME"
+  },
+  {
+    "title": "Le Film de la dernière BIAM bientôt en ligne!",
+    "youtube_url": "https://www.youtube.com/watch?v=Q_iN6xn0cic",
+    "description": "La Biennale Internationale d'Art Mural 6 organisée par le Collectif Renart va bientôt commencer. C'est l'occasion de partager avec vous le film de la dernière édition réalisé par Lucas Takerkart. On le met en ligne très prochainement : restez attentifs ;)",
+    "credits": "",
+    "year": "2023",
+    "video_duration": "14 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "Q_iN6xn0cic"
+  },
+  {
+    "title": "Nouvelle vidéo 'instant soufie' au jardin des plantes @  #lille #danse #soufi",
+    "youtube_url": "https://www.youtube.com/watch?v=02ge6u2uQQI",
+    "description": "Teaser réalisé pour la compagnie Attacafa La Franco-Iranienne Rana Gorgani, à travers la danse soufie, continue de « tourner pour donner un sens à l’existence »",
+    "credits": "",
+    "year": "2022",
+    "video_duration": "16 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "02ge6u2uQQI"
+  },
+  {
+    "title": "Nouvelle vidéo 'instant soufie' sur notre chaîne ð¥ð¥ð¥",
+    "youtube_url": "https://www.youtube.com/watch?v=AceWmcVqIFw",
+    "description": "Teaser réalisé pour la compagnie Attacafa La Franco-Iranienne Rana Gorgani, à travers la danse soufie, continue de « tourner pour donner un sens à l’existence »",
+    "credits": "",
+    "year": "2022",
+    "video_duration": "16 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "AceWmcVqIFw"
+  },
+  {
+    "title": "instant soufie - Attacafa, scène universelle nomade",
+    "youtube_url": "https://www.youtube.com/watch?v=tPWfIMUbD90",
+    "description": "Femme, vie, liberté.\nSoutien aux Iraniennes et aux Iraniens qui descendent dans la rue depuis la mort de Mahsa Amini pour protester contre la brutalité du régime iranien. Ce régime qui nourrit les inégalités politiques, sociales, et les discriminations juridiques, qui restreint les libertés, notamment envers les femmes.\nFace à une police des mœurs omniprésente, iels clament leur liberté.\nLa Franco-Iranienne Rana Gorgani, à travers la danse soufie, continue de « tourner pour donner un sens à l’existence ».\nEn soutiens à tous les iranien.ne.s et en souvenir de cette journée de mai 2021 nous vous repartageons cette vidéo tournée à Lille avec les danseurs et danseuses de Rana Gorgoni.\nhttps://danse-soufie.com/rana-gorgani-2/\nBalade - Kudsi Erguner (Sufi music of Turkey)\nAttacafa, scène universelle nomade https://www.facebook.com/Attacafa/",
+    "credits": "Direction Artistique: Rana Gorgani\nMusique:\nProduction:\nRéalisation : Cultur’All https://www.instagram.com/culturall_films/\nMontage : Jonathan Oliveira Caméras : Jonathan Oliveira, Lucas Takerkart, Justine Lescornez Drone : Lucas Takerkart",
+    "year": "2022",
+    "video_duration": "5 minutes 1 secondes",
+    "tags": [
+      "danse"
+    ],
+    "featured": false,
+    "_video_id": "tPWfIMUbD90"
+  },
+  {
+    "title": "Zoer - Solara Séquences",
+    "youtube_url": "https://www.youtube.com/watch?v=BzCFPQxxAQg",
+    "description": "Réalisé par Lucas Takerkart pour @ConditionDeRoubaix",
+    "credits": "Musique : @OursSamplus",
+    "year": "2022",
+    "video_duration": "3 minutes 21 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "BzCFPQxxAQg"
+  },
+  {
+    "title": "Buga na selva - Europa 2022",
+    "youtube_url": "https://www.youtube.com/watch?v=ORiGxV1MgdM",
+    "description": "Quand l’artiste BUGA alias Juliana Vila Nova venant de la ville d’Aracaju au Brésil vient en Europe, on en profite pour faire une vidéo.\nQuando a artista BUGA alias Juliana Vila Nova\nde Aracaju no Brasil vem na Europa, aproveitamos para fazer um vídeo.\nArtiste: Buga alias Juliana Vila Nova https://www.instagram.com/buga.one/\nParticipant: Clément Benzid Basset https://www.instagram.com/clement.benzid.basset/\nhttps://www.instagram.com/culturall_films/",
+    "credits": "Musique: Ours Samplus - Flying Ship https://www.youtube.com/c/OursSamplus https://www.instagram.com/ours_samplus/\nImages et réalisation: Jonathan Oliveira(alias Gérard au Brésil) Team CULTUR’ALL",
+    "year": "2022",
+    "video_duration": "2 minutes 40 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "ORiGxV1MgdM"
+  },
+  {
+    "title": "Mr Aya - Raggamuffin",
+    "youtube_url": "https://www.youtube.com/watch?v=rd6tilPebCg",
+    "description": "Le single RAGGAMUFFIN de MISTA AYA n'est pas disponible à l'écoute ni en\ntéléchargement sur les plateformes de streaming... Uniquement via BANDCAMP MISTA AYA ð ðhttps://mistaaya.bandcamp.com/releases FACEBOOK MISTA AYA https://www.facebook.com/mista.aya.official INSTAGRAM MISTA AYA https://www.instagram.com/mista_aya\nMIX / MASTERING : KWEZYDOCTOR KAIHMA STUDIO REALISATION : CULTUR'ALL (LUCAS / CARLOS / JONATHAN)\nMista Aya évolue dans la musique afro-caribéenne depuis son plus jeune âge. Il est actuellement un des meilleurs représentants du reggae et du dancehall du\nNord de la France en développant des paroles aux thématiques variées, sur des rythmes tout aussi éclectiques, passant de ballades roots à la soca, en passant par le dancehall ou le raggamuffin à l’ancienne.\nS'entourant de musiciens, frères de son, forgés dans le reggae\ndepuis plusieurs décennies et sur une idée instrumental de Sysao ( Isaman basse, jah miloudi claviers, Sysao claviers prog drum et Kwezydoctor pour le mix, l arrangement et le mastering, scalpel studio prises voix) Mr\nAYA\nnous offre un morceau fortement inspiré du style jamaiquain des années 60\ncomposé de sonorités plus moderne avec un texte qui fais l'éloge du mouvement raggamuffin francais donc il est lui meme activiste,\npetit clin d oeil humoristique en passant au franglais jamaicanisé.",
+    "credits": "AUTEUR : MISTA AYA DRUM PROG : SYSAO CLAVIERS : SYSAO, JAH MILOUDY BASSE : ISAMAN PRISE DE VOIX : SCALPEL STUDIO ARRANGEMENT : KWEZYDOCTOR / MISTA AYA / SYSAO / ISAMAN",
+    "year": "2022",
+    "video_duration": "2 minutes 29 secondes",
+    "tags": [
+      "clip"
+    ],
+    "featured": false,
+    "_video_id": "rd6tilPebCg"
+  },
+  {
+    "title": "Le titre 'Raggamuffin' de Mr Aya sera dispo ce dimanche sur la chaîne de Cultur'All ð¥ð¥ð¥",
+    "youtube_url": "https://www.youtube.com/watch?v=I9zzTkf7yVY",
+    "description": "Teaser réalisé pour la sortie du single Raggamuffin de Mista Aya",
+    "credits": "",
+    "year": "2022",
+    "video_duration": "8 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "I9zzTkf7yVY"
+  },
+  {
+    "title": "UNIK.E.S. Conférence 'Ladies in Rap' animée par THÉRÈSE avec Mando MCD, Ben PLG et Zazem @FLOW Lille",
+    "youtube_url": "https://www.youtube.com/watch?v=H6-03MRP7q4",
+    "description": "UNIK.E.S.\n‘Mieux vaut être unique que parfait!’\nUNIK.E.S. est un atelier d'Éducation aux Médias et à L’Information (EMI) , sous le prisme de l'éducation populaire (apprendre par le faire). Le projet a été construit entièrement par les enfants, du choix du titre UNIK.E.S aux thèmes abordés: les intersectionnalités. Les interviews, la vidéo et le montage live sont préparés et réalisés par les enfants du Centre Social et Culturel de l’ Arbrisseau, avec l’encadrement de notre équipe.\nCette vidéo est la captation de la conférence ‘Ladies in Rap’ animée par THÉRÈSE sur la thématique de la place des femmes dans le Hip-Hop et également les autres formes de discriminations liées à l’image des rappeuses. Organisé par La Cave Aux Poètes (https://caveauxpoetes.com/)\nCes ateliers ont été réalisés en partenariat avec Le FLOW et le Centre Social et Culturel\nde L'Arbrisseau avec le soutien du PNIM (pratiques numériques des images et médias) de la mairie de Lille.\nInvités: Mando MCD\nhttps://www.instagram.com/mando.mcd/?hl=fr Ben PLG\nhttps://instagram.com/ben_plg?igshid=YmMyMTA2M2Y= Elza Miské a.k.a. Zazem https://www.instagram.com/zazem/?hl=fr\nLieu: Le FLOW: https://instagram.com/flowlille?igshid=YmMyMTA2M2Y=\nPartenaires: Le FLOW: https://flow.lille.fr/ Mairie de LILLE:\nhttps://www.lille.fr/ Centre Social et Culturel de L'Arbrisseau: https://larbrisseau.com/",
+    "credits": "",
+    "year": "2022",
+    "video_duration": "1 heures 32 minutes 25 secondes",
+    "tags": [
+      "captation"
+    ],
+    "featured": false,
+    "_video_id": "H6-03MRP7q4"
+  },
+  {
+    "title": "UNIK.E.S. Interview de Sofiane Chalal a.k.a. Big Sof",
+    "youtube_url": "https://www.youtube.com/watch?v=wfd0WUMX4q4",
+    "description": "UNIK.E.S.\n'Il vaut mieux être unique que parfait!'\nUNIK.E.S.\nest un atelier d'Éducation aux Médias et à L’Information (EMI), sous le prisme de l'éducation populaire (apprendre par le faire). Le projet a été construit entièrement par les enfants, du choix du titre UNIK.E.S. aux thèmes abordés : les intersectionnalités. Les interviews, la vidéo et le montage live sont préparés et réalisés par les enfants du Centre Social et Culturel de l’ Arbrisseau, avec l’encadrement de notre équipe.\nNotre premier invité est Sofiane CHALAL a.k.a. Big SOF, danseur, chorégraphe, comédien émérite de la région. Sofiane a accepté de nous rencontrer durant la préparation du\nprojet “C’est mon Patrimoine” au Musée d’Histoire Naturelle de Lille.\nCes ateliers ont été réalisés en partenariat avec Le FLOW et le Centre Social et Culturel\nde L'Arbrisseau avec le soutien du PNIM (Pratiques Numériques des Images et Médias).\nArtiste: Sofiane Chalal\nInsta: https://www.instagram.com/sofiane_chalal_/?hl=fr\nLieu: Musée d'Histoire Naturelle Insta: https://www.instagram.com/mhnlille/?hl=fr https://www.lille.fr/\nPartenaires: Le FlOW: https://flow.lille.fr/ La Mairie de Lille : https://www.lille.fr/ Le Centre Social et Culturel de l'Arbrisseau: https://larbrisseau.com/",
+    "credits": "Musique: GooMar : 'Unspected Rendez-vous' Insta: https://www.instagram.com/goomar.beatz/?hl=fr https://www.youtube.com/user/GooMarBeatz",
+    "year": "2022",
+    "video_duration": "8 minutes 39 secondes",
+    "tags": [
+      "captation"
+    ],
+    "featured": false,
+    "_video_id": "wfd0WUMX4q4"
+  },
+  {
+    "title": "Xploration(S) - Geograffiti2 - Teaser",
+    "youtube_url": "https://www.youtube.com/watch?v=CGhgcIen37g",
+    "description": "XPLORATIONS(S), D'AUTRES HISTOIRES DE GRAFF de Lucas Takerkart\nProchaine projection : 13 juillet 2022 @ 19h @ La Condition Publique, Roubaix, pour le festival Pile au Rdv.\nCe film est animé par la passion d'explorer la ville autrement. Les guides sont des graffeurs du Nord de la France. Avant même que la notion de propriété privée existe, des gens laissaient leur trace sur les murs. Les endroits les plus reculés, qui résistent encore aux transformations urbaines, sont ceux où l'on trouve les graffitis les plus anciens. Par exemple, la plus vieille inscription dans ce film date du XVIIe s. A travers ces histoires de graffitis, rythmées par le\ndouble H du Hip Hop, on retrouve des bribes de l'Histoire avec un grand H.\nCinéma Le Métropole à Lille samedi 18 juin à 21h en compétition au festival de L'Acharnière.\nð½️ Street Art Movie Fest 2022 ð️Dimanche 29 mai à 15h15 ð©Esplanade Alain Le Ray, Caserne de Bonne, Grenoble\nð½️ [Sélection Officielle \\| SAMF2022]ð½️ ð½️ [Sélection Officielle \\|\nL'ACHARNIERE Lille ð½️ [Sélection Officielle FestiFrance (Brésil)",
+    "credits": "",
+    "year": "2022",
+    "video_duration": "2 minutes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "CGhgcIen37g"
+  },
+  {
+    "title": "Breeze Yoko @ Roubaix - Graffiti South Africa",
+    "youtube_url": "https://www.youtube.com/watch?v=TtT1MpHtk7k",
+    "description": "CURRENT AFFAIRS BREEZE YOKO\nInvité au printemps 2021 lors de la saison \"Un quartier généreux\", Breeze Yoko a réalisé une fresque sur le parking de la Condition Publique lors d'une résidence de création.\nCette peinture murale représentent un.e enfant le regard dirigé vers un bateau, intitulée “Current Affairs” (en français actualités). L’artiste souhaite à travers cette fresque, éveiller les libres interprétations et lectures du public, sans les contraindre par sa propre vision. Certain.e.s trouvent au personnage un air plein de curiosité, d’autres interprètent de la détermination ou de la tristesse. Certain.e.s lisent dans cette fresque le passé colonial, d’autres voient une évocation de voyage et de d’aventure. Dans la ville multiculturelle de Roubaix, les réactions et interprétations de cette œuvre abordant tour à tour le passé, le présent ainsi que le futur y seront aussi variées que les origines de ses habitants.",
+    "credits": "Réalisation : Cultur'all - https://www.youtube.com/channel/UCIHj... Musique : Ours Samplus",
+    "year": "2022",
+    "video_duration": "1 minutes 55 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "TtT1MpHtk7k"
+  },
+  {
+    "title": "Urbain.es - étape 2/2 - Maya Hayuk, Magda Sayeg, Aya Tarek, Robert Montgomery, Saype",
+    "youtube_url": "https://www.youtube.com/watch?v=PGuSTafvjv0",
+    "description": "",
+    "credits": "Réalisation : Lucas Takerkart Musique : Ours Samplus",
+    "year": "2022",
+    "video_duration": "2 minutes 53 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "PGuSTafvjv0"
+  },
+  {
+    "title": "Urbain.es - étape 1/2 - Yz, Saype, Sandra Fernandez & Marc Jenkins, Icy & Sot",
+    "youtube_url": "https://www.youtube.com/watch?v=PhaRvULol6c",
+    "description": "",
+    "credits": "L'exposition Urbain.es by Magda Danysz @ la Condition Publique. Réalisation : Lucas Takerkart Musique : Ours Samplus - Hardest Atmosphere",
+    "year": "2022",
+    "video_duration": "2 minutes 10 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "PhaRvULol6c"
+  },
+  {
+    "title": "Ana Barriga 'Un Monde Pour Vous'  Fresque #Roubaix",
+    "youtube_url": "https://www.youtube.com/watch?v=VuHTf90oUmk",
+    "description": "Artiste: Ana Barriga https://www.instagram.com/anabarrigaoliva/?hl=fr\nVidéo réalisée par Lucas Takerkart\nhttps://www.instagram.com/alpha_bandit/?hl=fr",
+    "credits": "Images additionnelles : Justine Lescornez\nMusique : T-Jah Music 'Mi Cura' https://www.youtube.com/c/TJAHMUSIC",
+    "year": "2021",
+    "video_duration": "2 minutes 39 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "VuHTf90oUmk"
+  },
+  {
+    "title": "Biennale Internationale d'Art Mural 2021 // Session 4 // Kat&Action, DavidBruce",
+    "youtube_url": "https://www.youtube.com/watch?v=y1uYSGfR91Y",
+    "description": "",
+    "credits": "Images et montage : Lucas Takerkart Musique Ours Samplus",
+    "year": "2021",
+    "video_duration": "1 minutes 13 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "y1uYSGfR91Y"
+  },
+  {
+    "title": "Biennale Internationale d'Art Mural 2021 // Session 3 avec Lem, San Momo, Jam Graffiti Bois Blancs",
+    "youtube_url": "https://www.youtube.com/watch?v=cydknDF3b9A",
+    "description": "",
+    "credits": "Musique : Ours Samplus",
+    "year": "2021",
+    "video_duration": "1 minutes 13 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "cydknDF3b9A"
+  },
+  {
+    "title": "Biennale Internationale d'Art Mural 2021 LILLE //Session 2 : Marko93 et  Twoone",
+    "youtube_url": "https://www.youtube.com/watch?v=9WUg4Bh4mdI",
+    "description": "Résumé en image de la deuxième session de la 5e Biennale d'Art Mural avec Marko 93 (France) et Twoone (Japon). Pulvérisateur de peinture, giclures, la peinture coule et on adore ça!\norganisation: collectif renart https://collectif-renart.com/\nMusique by Ours Samplus https://www.youtube.com/channel/UCUy_KSGhKNNFK5Ho2U0I7Zg",
+    "credits": "",
+    "year": "2021",
+    "video_duration": "1 minutes 8 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "9WUg4Bh4mdI"
+  },
+  {
+    "title": "Biennale Internationale d'Art Mural 2021 LILLE // Session 1",
+    "youtube_url": "https://www.youtube.com/watch?v=Y13VovDVh48",
+    "description": "BIAAAAAAM! ð¥ La première session de la Biennale Internationale d'Art Mural est terminée.\nRetour en vidéo sur les réalisations des artistes : Rouge x Murad Subay x Haute Bouture x Jaune x Lor-K et tous les amis présents lors de la fresque collective à Hellemmes.\norganisation: collectif renart https://collectif-renart.com/\nMusique by Ours Samplus https://www.youtube.com/channel/UCUy_KSGhKNNFK5Ho2U0I7Zg",
+    "credits": "",
+    "year": "2021",
+    "video_duration": "1 minutes 4 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "Y13VovDVh48"
+  },
+  {
+    "title": "BIAM 5 // Graffitis révolutionnaires au Yémen et Egypte - JAMEEL SUBAY - Rêves de Révolution",
+    "youtube_url": "https://www.youtube.com/watch?v=8EvMg48Dqko",
+    "description": "Dans le cadre de la BIAM5, le Collectif Renart invite Jameel Subay à exposer 10 photos dans le leur local de la rue du Faubourg des Postes à Lille.\nLe témoignage d'un rêve, le printemps arabe, il y a dix ans. Un moment magique pour des millions de gens qui, le temps d'une révolte, ont touché du doigt l'espoir de dessiner un chemin empreint de liberté et de dignité. De la Tunisie au Yémen en passant par la Lybie, l'Égypte, le Bahreïn, la Syrie, les peuples se sont soulevés pour tenter l'impossible : exister et respirer.\nA travers \"Rêves de révolution\", le photographe Jameel Subay offre une plongée dans les graffitis révolutionnaires qui ont accompagnés les soulèvements populaires au Yémen et en Égypte.\nLà-bas plus qu'ailleurs, ces quelques traces inscrites à la dérobée renseignent autant qu'elles objectivent les charges politiques et mentales de celles et ceux qui ont\nosé rêver l'alternative... pour eux, pour elles, pour les autres.\nÉphémères dans leur essence même, ces graffitis ont disparu. Jameel Subay a su les capter.\norganisation: collectif renart https://collectif-renart.com/",
+    "credits": "",
+    "year": "2021",
+    "video_duration": "3 minutes 52 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "8EvMg48Dqko"
+  },
+  {
+    "title": "Demo Reel 2020",
+    "youtube_url": "https://www.youtube.com/watch?v=JQaC27joO_A",
+    "description": "Retour en images de l'année 2020 de Cultur'All.\nMerci à toutes les personnes grâce à qui cela a été possible\nImages et Montages : Jonathan Oliveira https://www.instagram.com/jaw_jo/ Issam Ourdach https://www.instagram.com/samioneline/ Carlos Bernal Herrero https://www.instagram.com/wanwondering/ Lucas Tartekart\n\"the apogee\" de Goomar https://www.youtube.com/channel/UCFJzs8Unpz08jtuWt5VR8tw",
+    "credits": "Musique:",
+    "year": "2021",
+    "video_duration": "1 minutes 51 secondes",
+    "tags": [
+      "demo reel"
+    ],
+    "featured": false,
+    "_video_id": "JQaC27joO_A"
+  },
+  {
+    "title": "Géograffiti - D'Autres Visages du Nord (Documentaire intégral) 2017",
+    "youtube_url": "https://www.youtube.com/watch?v=TuZpWf0NtNQ",
+    "description": "\"Géograffiti, D’autres Visages du Nord\" est le fruit d’un travail de recherches, de rencontres et de visites s'étalant sur trois ans.\nPassionné par les marges urbaines, filmer les graffs était un prétexte et une belle opportunité pour découvrir des endroits souvent proches mais méconnus. Car les graffeurs pratiquent la ville autrement en s’aventurant dans ses recoins. La scène étant foisonnante d’initiatives, nous avons voulu mettre en lumière d’autres acteurs et d’autres pratiques tout en gardant une continuité avec un travail plus classique autour du Graffiti et du \"Street Art\" Institutionnel. Un des discours que l’on entend (trop) régulièrement est une critique du graffiti sauvage et une adulation du \"street art\" alors même qu’une bonne partie des streets artistes viennent du vandale ou tout du moins s’en inspirent dans leur manière d’occuper l’espace public. Nous avons donné la parole à différentes générations d’acteurs de la région NP2C. Leurs portraits esquissent par leurs particularités, une identité multiple du mouvement qui va souvent au-delà du graffiti.",
+    "credits": "Réalisation : Lucas Takerkart",
+    "year": "2020",
+    "video_duration": "48 minutes 36 secondes",
+    "tags": [
+      "documentaire"
+    ],
+    "featured": false,
+    "_video_id": "TuZpWf0NtNQ"
+  },
+  {
+    "title": "DOCUMENTAIRE / GEOGRAFFITI  D'autres visages du Nord  -  BIENTÔT SUR INTERNET",
+    "youtube_url": "https://www.youtube.com/watch?v=wcUGiEVpADI",
+    "description": "Le documentaire complet BIENTÔT EN LIGNE.\n\"Géograffiti, D’autres Visages du Nord\" est le fruit d’un travail de recherches, de rencontres et de visites s'étalant sur trois ans.\nPassionné par les marges urbaines, filmer les graffs était un prétexte et une belle opportunité pour découvrir des endroits souvent proches mais méconnus. Car les graffeurs pratiquent la ville autrement en s’aventurant dans ses recoins. La scène étant foisonnante d’initiatives, nous avons voulu mettre en lumière d’autres acteurs et d’autres pratiques tout en gardant une continuité avec un travail plus classique autour du Graffiti et du \"Street Art\" Institutionnel. Un des discours que l’on entend (trop) régulièrement est une critique du graffiti sauvage et une adulation du \"street art\" alors même qu’une bonne partie des streets artistes viennent du vandale ou tout du moins s’en inspirent dans leur manière d’occuper l’espace public. Nous avons donné la parole à différentes générations d’acteurs de la région NP2C. Leurs portraits esquissent par leurs particularités, une identité multiple du mouvement qui va souvent au-delà du graffiti.",
+    "credits": "Musique : Logic- Dead Presidents 3 (Instrumental).",
+    "year": "2020",
+    "video_duration": "1 minutes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "wcUGiEVpADI"
+  },
+  {
+    "title": "Week-end CULTUR'RAÏ à la Maison Folie Wazemmes",
+    "youtube_url": "https://www.youtube.com/watch?v=R8-YKFR10Eo",
+    "description": "L’association Cultur’All et la maison Folie de Wazemmes ont proposé un week-end pour mettre à l'honneur les musiques et les danses du Maghreb autour d'un des éléments essentiels de sa musique actuelle : LE RAÏ ! (29 février et 1er mars 2020)\nToute l'équipe de Cultur'all : Jojo, Rémi, Louis, Martin, Bib, Loïc, Manon, Carlos, Issam, Kiran, Zahia, Lucas, Elias. Les familles familles Missiaen, Takerkart et Lecocq. Une spéciale pour Jeff, Chouchou et Kiki. Les bars et commerçants de Wazemmes et de la rue de l'Alma à Roubaix. Le Pavillon du Tsing Tao. Et tout le public pour sa bonne humeur et sa convivialité !\nConférence de Hadj Miliani : Bref Panorama historique sur le Raï\nLIEN : https://soundcloud.com/culturall/bref-panorama-historique-sur-lhistoire-du-rai-par-hadj-miliani\nYa Zina - Raina Raï\nCheikha Rimitti - El Alia N'batou Ahna",
+    "credits": "Remerciement : Les Ambassadeurs, La Maison Folie Wazemmes, L'équipe de KPA-Moulins, 301 On Air (Radio Boomerang), Des Punaises Dans l'Crépi (Radio Campus Lille), Autour d'un thé et Arabesque (Pastel FM), Mouloud Hamidi et Karim Mraini (Bar Live), Hani Rais (Radio Campus Paris), Fatima Bass.\nMusique :",
+    "year": "2020",
+    "video_duration": "2 minutes 21 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "R8-YKFR10Eo"
+  },
+  {
+    "title": "Friche industrielle du Nord. Session graffiti des familles.",
+    "youtube_url": "https://www.youtube.com/watch?v=0L8953RVKGU",
+    "description": "Prêter une frîche industrielle du Nord au Collectif Renart pour une petite session de graff des familles avec plus d'une vingtaine d'artistes.\nLa frîche s’est faite repeindre sous tous les angles. Une grosse trentaine d’œuvres a été créé.\nFACEBOOK : https://www.facebook.com/assoculturall/",
+    "credits": "Réalisation : Cultur'all Musique : Billa Qause - Am I Blue ( Mononome Remix ) https://www.youtube.com/watch?v=c6SUi4AIBXQ lieu : \"Architecture et Matériaux Authentiques\" à Tourcoing.",
+    "year": "2020",
+    "video_duration": "3 minutes 36 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "0L8953RVKGU"
+  },
+  {
+    "title": "LA FRESQUE DU FLOW  avec  ZUBA - SHURE - KORSÉ - SAMI",
+    "youtube_url": "https://www.youtube.com/watch?v=KZLOLzePXNI",
+    "description": "Fresque du FLOW à Lille.\nSeptembre 2019. #assoculturall\nSHURE : www.instagram.com/reuhrs_csx_vms KORSÉ : www.instagram.com/kafekorse SAMI : www.instagram.com/samione_works",
+    "credits": "",
+    "year": "2020",
+    "video_duration": "2 minutes 49 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "KZLOLzePXNI"
+  },
+  {
+    "title": "Demo Reel 2019 - Cultur'all",
+    "youtube_url": "https://www.youtube.com/watch?v=F4r4cFpsURc",
+    "description": "Démo Reel extrait des projets de l'année 2019. Nous entamons 2020 avec l'ambition de promouvoir d'avantage les cultures urbaines et populaires. Nous tenons à vous remercier toutes et tous pour la confiance soutenue que vous nous accordez.",
+    "credits": "",
+    "year": "2020",
+    "video_duration": "3 minutes 5 secondes",
+    "tags": [
+      "demo reel"
+    ],
+    "featured": false,
+    "_video_id": "F4r4cFpsURc"
+  },
+  {
+    "title": "Oréli Paskal - illustration - Café Jean - Chillin' à #Wazemmes #Lille",
+    "youtube_url": "https://www.youtube.com/watch?v=Ka4YeupLG9o",
+    "description": "",
+    "credits": "Vidéo : Lucas Takerkart Musique : Ours Samplus X Grandhuit - Downtown",
+    "year": "2019",
+    "video_duration": "1 minutes 30 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "Ka4YeupLG9o"
+  },
+  {
+    "title": "Lelin Alves Graffiti Brasil Friterie Lille Sud France Tudo Bom #LSD #Géograffiti",
+    "youtube_url": "https://www.youtube.com/watch?v=0UKtKRPArD8",
+    "description": "Big up Lady Alézia et Mike ! Artiste Lelin Alves : https://www.instagram.com/lel1n/ Musique : BadSista & Tap - Na Madruga (Branko Edit)\ncultur-all.org https://www.facebook.com/geograffitifilm/",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "2 minutes 48 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "0UKtKRPArD8"
+  },
+  {
+    "title": "Défilé Jambaar by Lô #RdvHH2019",
+    "youtube_url": "https://www.youtube.com/watch?v=oq-Q8jCVl0Q",
+    "description": "Pour les RDVHH2019 à Lille Marième Lô a préparé une collection Hip Hop. Voici la vidéo du défilé qui s'est passé à la gare SaintSo à Lille.",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "3 minutes 22 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "oq-Q8jCVl0Q"
+  },
+  {
+    "title": "Aïda Fane Teinturière - Textile - Artisans et Savoir Faire de Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=yMae9rTPRmI",
+    "description": "Découvrez les savoir faire des artisans de Saint-Louis du Sénégal à travers ces portraits vidéos réalisés en 2016 par Lucas Takerkart pour l'association N'Dart.",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "7 minutes 26 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "yMae9rTPRmI"
+  },
+  {
+    "title": "Moussa Cisse CAMARA - Tisserand - Artisans Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=23oiXNhJvTY",
+    "description": "Découvrez les savoir faire des artisans de Saint-Louis du Sénégal à travers ces portraits vidéos réalisés en 2016 par Lucas Takerkart pour l'association N'Dart.",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "1 minutes 52 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "23oiXNhJvTY"
+  },
+  {
+    "title": "Yattou THIAM - Bijoutier - Artisans et Savoir Faire de Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=jyCBclXEuwc",
+    "description": "Bijouterie 'Le Thialene' 00 (221) 772073794\nDécouvrez les savoir faire des artisans de Saint-Louis du Sénégal à travers ces portraits vidéos réalisés en 2016 par Lucas Takerkart pour l'association N'Dart.",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "2 minutes 21 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "jyCBclXEuwc"
+  },
+  {
+    "title": "Fattou CISSE - Bijoux et Accessoires - Artisans Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=S_6b8QJzY8c",
+    "description": "Pharmacopée traditionnelle et perles anciennes : Fattou Cisse au marché N'Dartout à Saint-Louis. Merci à Absa Guisse pour la traduction. Découvrez les savoir faire des artisans de Saint-Louis du Sénégal à travers ces portraits vidéos réalisés en 2016 par Lucas Takerkart pour l'association N'Dart.",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "2 minutes 26 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "S_6b8QJzY8c"
+  },
+  {
+    "title": "Fallou DIA - Maroquinerie - Artisans et Savoir Faire de Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=RVSDELzUNHQ",
+    "description": "Découvrez les savoir faire des artisans de Saint-Louis du Sénégal à travers ces portraits vidéos réalisés en 2016 par Lucas Takerkart pour l'association N'Dart.",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "3 minutes 45 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "RVSDELzUNHQ"
+  },
+  {
+    "title": "Sokhna DIOP - Bijouterie - Artisans Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=_yhnTZqovno",
+    "description": "",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "3 minutes 22 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "_yhnTZqovno"
+  },
+  {
+    "title": "Aminata Diop - Styliste - Artisans Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=IG7syRYbdKM",
+    "description": "",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "3 minutes 23 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "IG7syRYbdKM"
+  },
+  {
+    "title": "Adja DUPUIS - Batik - Artisans et Savoir Faire de Saint Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=hLrwkNLmNYc",
+    "description": "Série de portraits d'artisans de Saint-Louis du Sénégal réalisés par Lucas Takerkart pour l'association Ndart",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "3 minutes 2 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "hLrwkNLmNYc"
+  },
+  {
+    "title": "Makhtar NIANG - Bijoutier - Filigrane en Argent - Artisans Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=AvLHDtERdek",
+    "description": "",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "3 minutes 18 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "AvLHDtERdek"
+  },
+  {
+    "title": "Lamine WADE - Styliste - Artisans et Savoir Faire de Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=ST40aXd8OXI",
+    "description": "",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "4 minutes 20 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "ST40aXd8OXI"
+  },
+  {
+    "title": "BIAM 2017 SEM3 Pso Man, Fred Logez, Maks, Dany Boy, Gemo, SanOne et Michael Barek and more",
+    "youtube_url": "https://www.youtube.com/watch?v=VYg1cZrNlno",
+    "description": "Semaine 3 de la Biennale International d'Art Mural 2017 dans les villes de Lille, Fives et Hellemmes (quartier de l'Epine).",
+    "credits": "",
+    "year": "2019",
+    "video_duration": "6 minutes 37 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "VYg1cZrNlno"
+  },
+  {
+    "title": "BIAM 2017 SEM2 Opoil, SA Crew, Popay, Poisson",
+    "youtube_url": "https://www.youtube.com/watch?v=ViL5L_51s28",
+    "description": "Semaine 2 de la Biennale Internationale d'Art Mural qui s'est déroulée dans les ville de Villeneuve d’Ascq, Lille Fives et Saint-André.",
+    "credits": "",
+    "year": "2018",
+    "video_duration": "5 minutes 11 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "ViL5L_51s28"
+  },
+  {
+    "title": "BIAM 2017 SEM1 : Mary Limonade, Yosra Mojtahedi, Olga Alexopoulou, Collectif Renart",
+    "youtube_url": "https://www.youtube.com/watch?v=AyucE_xSRR0",
+    "description": "Première semaine de la Biennale Internationale d'Art Mural 2017 : Denain et Wavrechain-sous-Denain.",
+    "credits": "",
+    "year": "2018",
+    "video_duration": "7 minutes 2 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "AyucE_xSRR0"
+  },
+  {
+    "title": "La Mode a du Coeur Au Festival Blouza à Oujda",
+    "youtube_url": "https://www.youtube.com/watch?v=nuMpy0GBpFo",
+    "description": "",
+    "credits": "",
+    "year": "2018",
+    "video_duration": "9 minutes 34 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "nuMpy0GBpFo"
+  },
+  {
+    "title": "Teaser La Mode a du Coeur au festival Blouza à Oujda",
+    "youtube_url": "https://www.youtube.com/watch?v=owsT5a0eV-4",
+    "description": "",
+    "credits": "",
+    "year": "2018",
+    "video_duration": "1 minutes 34 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "owsT5a0eV-4"
+  },
+  {
+    "title": "Défilé Lô For World Citizens - Rendez-Vous HH",
+    "youtube_url": "https://www.youtube.com/watch?v=MjDjlv3H6P0",
+    "description": "Entrez dans l'univers de Lô For World Citizens grâce à ce retour en image du défilé, présenté le Samedi 2 Juin 2018 à la Gare Saint Sauveur pour les Rendez-vous Hip-Hop.\nReplongez dans l'ambiance du défilé et redécouvrez les créations présentées.\nRemerciement à/aux :\nL'équipe : Styliste :\nLa Gare Saint-Sauveur",
+    "credits": "Marième Missiaen Assistante Styliste : Albane Houvenagel Marketing et communication : Ishane Fall et Hélène Hélaouët Vidéastes : Lucas Takerkart, CKO Art, Jérémy Lenoir La Maison de Quartier Moulins : Aïssatou Diouf Logistique : Rémy Gausin Musique : T-Jah Music Organisateurs : Cultur'All, Le Flow,",
+    "year": "2018",
+    "video_duration": "3 minutes 13 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "MjDjlv3H6P0"
+  },
+  {
+    "title": "Lô For World Citizens - Fashion Teaser",
+    "youtube_url": "https://www.youtube.com/watch?v=pjbHfYjIvfo",
+    "description": "Teaser de la collection capsule Lô créée à l'occasion des Rendez-Vous Hip Hop. Cette collection sera présentée le 2 juin 2018 à la Gare Saint Sauveur (Lille) à 18h.",
+    "credits": "Réalisation : Lucas Takerkart Styliste : Marième Missiaen Modèle Femme : Réhane Niang Modèle Homme : Chandy Bakadi Assistante styliste : Albane Houvenagel Assistante communication visuelle : Hélène Helaouet Musique : \"Crash\" de T-JAH",
+    "year": "2018",
+    "video_duration": "1 minutes 59 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "pjbHfYjIvfo"
+  },
+  {
+    "title": "Géograffiti - D'Autres Visages du Nord - Teaser",
+    "youtube_url": "https://www.youtube.com/watch?v=bmnRgdpCZ2g",
+    "description": "\"Géograffiti, D’autres Visages du Nord est le fruit d’un travail de recherches, de rencontres et de visites sur plus de trois ans.\nPassionné par les marges urbaines, filmer les graffs était un prétexte et une belle opportunité pour découvrir des endroits souvent proches mais méconnus car les graffeurs pratiquent la ville autrement en s’aventurant dans ses recoins. La scène étant foisonnante d’initiatives, je voulais mettre en lumière d’autres acteurs et d’autres pratiques tout en gardant une continuité avec mon travail plus classique autour du Graffiti et du Street Art Institutionnel. Car un des discours que l’on entend (trop) régulièrement est une critique du graffiti sauvage et une adulation du street art alors même qu’une bonne partie des streets artistes viennent du vandale ou tout du moins s’en inspirent dans leur manière d’occuper l’espace public. J’ai donc donné la parole à différentes générations d’acteurs de la région NP2C. Leurs portraits esquissent par leurs particularités, une identité multiple du mouvement qui va souvent au-delà du graffiti\".",
+    "credits": "Réalisation : Lucas Takerkart Images additionnelles : Issam Ourhdach, Marc Antoine Martel Montages additionnels : Thomas Dadoun Post-Production / Habillages : Issam Ourhdach Mixé par : Jessie James (Studio Apollon XIII) Musiques : Renoiser, Mayi, Scalpel Studio et Wacky T, Ours Samplus, Sheuko, Mayi Produit par : Cultur'all en collaboration avec : Pictanovo et le Flow",
+    "year": "2018",
+    "video_duration": "2 minutes 18 secondes",
+    "tags": [
+      "teaser"
+    ],
+    "featured": false,
+    "_video_id": "bmnRgdpCZ2g"
+  },
+  {
+    "title": "Wecco 2017 :  échange autour du stylisme entre Lille et SaintLouis",
+    "youtube_url": "https://www.youtube.com/watch?v=zWMoBPnPwpI",
+    "description": "Cette vidéo présente les différentes réalisations 2017 dans le cadre du projet Wecco qui avait comme thème la dentelle. Nous avons invité deux stylistes saint-louisiens dans le Nord et différentes tenues ont été confectionnées pour le défilé de la mode a du Cœur.",
+    "credits": "",
+    "year": "2018",
+    "video_duration": "6 minutes 40 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "zWMoBPnPwpI"
+  },
+  {
+    "title": "OLD School - Fresque Flow - Di(x)Visions",
+    "youtube_url": "https://www.youtube.com/watch?v=XgUsI_7fAWE",
+    "description": "Organisée par le Collectif Renart avec : Amty - 3zer - Logik - Mako - Deraw - Pones - Stone - Sore - Ters -Sar - Apse - Hipy - Heaf - MRecidivist\nFresque réalisée dans le cadre de l'exposition Di(x)Visions visible au Flow du 13 octobre au 10 décembre 2017.",
+    "credits": "Vidéo : Cultur'All Musique : Samione",
+    "year": "2017",
+    "video_duration": "2 minutes 35 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "XgUsI_7fAWE"
+  },
+  {
+    "title": "BIG SESSION - Jeroo, Sly2, Eyes B, Defo, Spyre, Grey, Reaphe, Eror - Graffiti Lille",
+    "youtube_url": "https://www.youtube.com/watch?v=gP3kTekrLhU",
+    "description": "",
+    "credits": "Images et Montage : Lucas Takerkart et Thomas Dadoun Production : Cultur'All Musiques : SAMIONE (Terroir Prod) ; Yoshi et Faya BraZ (The Beat And The Voice), Cosmo et Cozo et Le Tigre X Mr OGZ et Ill Heaven (WelsH Recordz)",
+    "year": "2017",
+    "video_duration": "8 minutes 31 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "gP3kTekrLhU"
+  },
+  {
+    "title": "Teaser N'Dart - Artisans et Savoir Faire de Saint-Louis du Sénégal",
+    "youtube_url": "https://www.youtube.com/watch?v=_N_n5i__Wn4",
+    "description": "Réalisation vidéo : cultur-all.org Commanditaire : www.iddinternational.com/ndart",
+    "credits": "",
+    "year": "2016",
+    "video_duration": "2 minutes 48 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "_N_n5i__Wn4"
+  },
+  {
+    "title": "Graffiti Senegal - Festigraff 6 - Set ci Diaamu Yallah La Bokk",
+    "youtube_url": "https://www.youtube.com/watch?v=0x7rpbiNxx0",
+    "description": "Sélection officielle de l'Urban Film Festival\nFilm de Lucas Takerkart\nEntretien avec Ati Diallo, directeur du Festigraff, sur l'engagement social du graffiti autour d'un mur peint à Rufisque dont le thème est \"Set ci Diaamu Yallah La Bokk\" \"être propre c'est se rapprocher de\ndieu\".",
+    "credits": "Production : Cultur'All Musique de Samione (Terroir Prod)",
+    "year": "2016",
+    "video_duration": "8 minutes 15 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "0x7rpbiNxx0"
+  },
+  {
+    "title": "#LoiTravail #Lille 26/05/16 Casserolade devant le Conseil Régional",
+    "youtube_url": "https://www.youtube.com/watch?v=E0Ujp4TzG4I",
+    "description": "",
+    "credits": "",
+    "year": "2016",
+    "video_duration": "2 minutes 56 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "E0Ujp4TzG4I"
+  },
+  {
+    "title": "#BIG7 - Battle International de Graffiti - Lille",
+    "youtube_url": "https://www.youtube.com/watch?v=yLXcLIVN4IQ",
+    "description": "",
+    "credits": "Images et Réalisation : Lucas Takerkart Post-production : Thomas Dadoun (L’œil et la Lune) Images additionnelles : Issam Ourdach Production : Cultur'All Musiques : Samione et Sir Plus",
+    "year": "2016",
+    "video_duration": "9 minutes 30 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "yLXcLIVN4IQ"
+  },
+  {
+    "title": "Biennale Internationale d'Art Mural 2015 - Le Film - Lille",
+    "youtube_url": "https://www.youtube.com/watch?v=nA8J5BZfIGY",
+    "description": "",
+    "credits": "Réalisation, images et montage : LucasTakerkart Images additionnelles : Naïm Aouaichia Musiques et Habillages : Samione (Terroir Prod) Habillages additionnels : Thomas Dadoun (L'oeil et la Lune) Son : Jessie James Rosquin (Studio Appollon XIII) Production : Cultur'All/Collectif Renart Merci à Jérémie Lenoir (Foniké) pour les conseils",
+    "year": "2016",
+    "video_duration": "25 minutes 51 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "nA8J5BZfIGY"
+  },
+  {
+    "title": "Block Party Calais",
+    "youtube_url": "https://www.youtube.com/watch?v=nsWEl07WwUE",
+    "description": "",
+    "credits": "",
+    "year": "2015",
+    "video_duration": "1 minutes 23 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "nsWEl07WwUE"
+  },
+  {
+    "title": "Cartograffiti - Sao Paolo - Brésil",
+    "youtube_url": "https://www.youtube.com/watch?v=JzEQtZ0Jwb8",
+    "description": "Stop Motion réalisé en 2012 à São Paulo (Brésil) par Lucas Takerkart.",
+    "credits": "",
+    "year": "2015",
+    "video_duration": "58 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "JzEQtZ0Jwb8"
+  },
+  {
+    "title": "Jam Graffiti Lille BIAM2015",
+    "youtube_url": "https://www.youtube.com/watch?v=D6SW3B5Zm4Q",
+    "description": "",
+    "credits": "",
+    "year": "2015",
+    "video_duration": "1 minutes 20 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "D6SW3B5Zm4Q"
+  },
+  {
+    "title": "#MoreThanAmigrant Le Mur",
+    "youtube_url": "https://www.youtube.com/watch?v=wrd_XeDAsGI",
+    "description": "Une journée de solidarité s'est tenue le 19 sept. 2015 à Calais. Lors de cet événement, un mur symbolique a été érigé et recouvert de graffiti. #MoreThanAmigrant #RefugeesWelcome #Calais",
+    "credits": "",
+    "year": "2015",
+    "video_duration": "1 minutes 49 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "wrd_XeDAsGI"
+  },
+  {
+    "title": "BIAM 2015 Teaser",
+    "youtube_url": "https://www.youtube.com/watch?v=V2EUjOeaBLE",
+    "description": "Samione",
+    "credits": "Production : Cultur'All/Collectif Renart Réalisation : Lucas Takerkart Montage : Thomas Dadoun Musique :\nArrangements : Terroir Productions",
+    "year": "2015",
+    "video_duration": "1 minutes 25 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "V2EUjOeaBLE"
+  },
+  {
+    "title": "VOS #3 Lille : Attaque de Squat et extincteur de peinture sur la gendarmerie",
+    "youtube_url": "https://www.youtube.com/watch?v=70Xv8FcBnrc",
+    "description": "Vision of Society ce sont des petits reportages sur l'actualité sociale et culturelle. Ici, c'est la tentative d'évacuation d'un squat lillois en plein après midi.",
+    "credits": "Musique : Samione et TimJah (Terroir Productions)",
+    "year": "2015",
+    "video_duration": "5 minutes 18 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "70Xv8FcBnrc"
+  },
+  {
+    "title": "Lille Graffiti Couleur vs Grisaille semi fail",
+    "youtube_url": "https://www.youtube.com/watch?v=43xOMCFEYkU",
+    "description": "Fresque sur un CAT abandonné\navortée par la police municipale...\nInstru : SamiOne /TimoTeA JaH au clavier",
+    "credits": "",
+    "year": "2015",
+    "video_duration": "1 minutes 26 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "43xOMCFEYkU"
+  },
+  {
+    "title": "L'usine à mémé",
+    "youtube_url": "https://www.youtube.com/watch?v=9JLjS_eFEqE",
+    "description": "Petite vidéo de l'exposition sur le film d'animation \"L'usine à mémé\" d'Oréli Paskal et Jérôme Desliens à l'Hospice d'Havré (Tourcoing).",
+    "credits": "",
+    "year": "2014",
+    "video_duration": "1 minutes 39 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "9JLjS_eFEqE"
+  },
+  {
+    "title": "Défilé 31  Lô créations /  hiver 2014",
+    "youtube_url": "https://www.youtube.com/watch?v=p4txc5imaKw",
+    "description": "Présentation de la collection Lô Créations, Automne Hiver\n2014/2015 lors du Défilé 31 à Croix dans le cadre du Gospelfest",
+    "credits": "",
+    "year": "2014",
+    "video_duration": "2 minutes 12 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "p4txc5imaKw"
+  },
+  {
+    "title": "Live Painting_Fred Chauvain",
+    "youtube_url": "https://www.youtube.com/watch?v=3cXYj2q7bzU",
+    "description": "Peinture : Fred Chauvain Saxophone : J. Gavinelli Caméra et montage : Lucas Takerkart",
+    "credits": "",
+    "year": "2014",
+    "video_duration": "2 minutes 40 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "3cXYj2q7bzU"
+  },
+  {
+    "title": "Lille Ring United - Club de boxe anglaise / Teaser",
+    "youtube_url": "https://www.youtube.com/watch?v=vCH3QM76oGU",
+    "description": "Lille Ring United, Club de boxe anglaise: http://www.lille-ring-united.fr/",
+    "credits": "Réalisation: Cultur'all (Marc-Antoine Martel & Thomas Dadoun) Musique: Samione (Terroir Prod') Website : http://www.cultur-all.org Facebook : http://www.facebook.com/assoculturall",
+    "year": "2014",
+    "video_duration": "2 minutes 52 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "vCH3QM76oGU"
+  },
+  {
+    "title": "VOS #2 M. Chat à Lille feat. M. Cana et Kecla",
+    "youtube_url": "https://www.youtube.com/watch?v=9G0pUym5tuM",
+    "description": "Vision of Society - Cultur'All\nV.O.S. est une série de reportages sur l'actualité sociale et culturelle dans le Nord-Pas-de Calais. Les sujets sont choisis par nos adhérents et peuvent être proposés par des personnes et des associations partenaires : com@cultur-all.org\nDans le cadre d'une fresque à la gare Lille Flandres organisée par le Collectif Renart et Mr Cana, nous avons rencontré M.Chat.",
+    "credits": "Production : Cultur'All Réalisation et Montage : Lucas Takerkart Etallonnage : Marc Antoine Martel Seconde Caméra : Thomas Dadoun et Issam Musique : Pinlinlin Dub - KaAaS - Terroir Prod Générique : Vision of Society par Jimmy Lovlov en téléchargement libre ici : http://terroirproductions.bandcamp.com/album/terroir-tape",
+    "year": "2014",
+    "video_duration": "4 minutes 41 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "9G0pUym5tuM"
+  },
+  {
+    "title": "SLIMANE - Fous le feu - Live @ Finale des Buzz Booster NPDC #5",
+    "youtube_url": "https://www.youtube.com/watch?v=Ae4rrXjUsqQ",
+    "description": "Captation Live du morceau \"Fous le feu\" de Slimane, réalisée lors de la finale Buzz Booster Nord Pas-de-Calais #5, à la Maison Folie Wazemmes - Lille.\nSlimane: https://www.facebook.com/slimane.offishal Cultur'all: http://www.cultur-all.org Call 911: http://www.call911.fr/",
+    "credits": "Réalisation: Cultur'All en partenariat avec Call 911",
+    "year": "2014",
+    "video_duration": "4 minutes 50 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "Ae4rrXjUsqQ"
+  },
+  {
+    "title": "MC METIS - Hommage à mes référents - Live @ Finale des Buzz Booster NPDC #5",
+    "youtube_url": "https://www.youtube.com/watch?v=p3pY-I1dFnE",
+    "description": "Captation Live du morceau \"Hommage à mes référents\" de Mc Métis, réalisée lors de la finale Buzz Booster Nord Pas-de-Calais #5, à la Maison Folie Wazemmes - Lille.\nMc Metis: https://www.facebook.com/mcmetisnet?fref=ts Cultur'all: http://www.cultur-all.org Call 911: http://www.call911.fr/",
+    "credits": "Réalisation: Cultur'All en partenariat avec Call 911",
+    "year": "2014",
+    "video_duration": "5 minutes 24 secondes",
+    "tags": [
+      "captation"
+    ],
+    "featured": false,
+    "_video_id": "p3pY-I1dFnE"
+  },
+  {
+    "title": "LA STORM - L'encre - Live @ Finale des Buzz Booster NPDC #5",
+    "youtube_url": "https://www.youtube.com/watch?v=2CM_wlmPa0Y",
+    "description": "Captation Live du morceau \"L'encre\" de La Storm, réalisée lors de la finale Buzz Booster Nord Pas-de-Calais #5, à la Maison Folie Wazemmes - Lille.\nLa Storm: www.facebook.com/La.Storm.Tornade Cultur'all: http://www.cultur-all.org Call 911: http://www.call911.fr/",
+    "credits": "Réalisation: Cultur'All en partenariat avec Call 911",
+    "year": "2014",
+    "video_duration": "3 minutes 43 secondes",
+    "tags": [
+      "captation"
+    ],
+    "featured": false,
+    "_video_id": "2CM_wlmPa0Y"
+  },
+  {
+    "title": "VOS #1 La mairie de Calais censure le festival UNISON",
+    "youtube_url": "https://www.youtube.com/watch?v=xRxooMVjbNg",
+    "description": "Vision Of Society est une série de reportages dans lesquels nous partons à la rencontre d'acteurs sociaux et culturels. Pour le premier, nous sommes allés à Calais rencontrer Lou qui avait monté le festival UNISON. Il\nétait censé permettre aux migrants et aux calaisiens de se rencontrer dans un contexte festif et détendu, mais la mairie ne l'entendait pas ainsi : quelques jours avant, le festival est annulé...\nMusique du générique : Vision of Society par Jimmy Lovlov extrait de la Terroir Tape : http://terroirproductions.bandcamp.com/album/terroir-tape",
+    "credits": "",
+    "year": "2014",
+    "video_duration": "3 minutes 11 secondes",
+    "tags": [
+      "couverture culturelle"
+    ],
+    "featured": false,
+    "_video_id": "xRxooMVjbNg"
+  }
+]


### PR DESCRIPTION
## Summary

- Ajout de `projects_import.json` : 97 projets extraits du Google Sheet Cultur'All (2014–2024)
- Chaque projet contient : `title`, `youtube_url`, `description`, `credits`, `year`, `video_duration`, `tags`, `featured`, `_video_id`
- La description et les crédits ont été séparés automatiquement (crédits techniques détectés par pattern de rôles : Réalisation, Musique, Montage, etc.)
- Les tags correspondent aux types de contenu de la chaîne : `clip`, `documentaire`, `teaser`, `couverture culturelle`, `danse`, `demo reel`, `captation`, `réel`

## Utilisation

Ce fichier est destiné à être passé à un script d'insertion Wagtail sur le VPS de production. Points d'attention :

- `description` et `credits` sont en texte brut — les wrapper en `<p>...</p>` pour les `RichTextField` Wagtail
- `_video_id` (préfixé `_`) sert uniquement à associer les thumbnails existants (`{video_id}.jpg`)
- `featured: false` pour tous les projets par défaut — à ajuster manuellement

## Stats

- 97 projets au total
- 41 avec des crédits extraits
- 76 avec une description
- Années couvertes : 2014 → 2024

🤖 Generated with [Claude Code](https://claude.com/claude-code)