### PR TITLE
refactor(pages): convertir les pages statiques en Pages Wagtail

### DIFF
--- a/backend/pages/migrations/0003_create_staticcontentpage.py
+++ b/backend/pages/migrations/0003_create_staticcontentpage.py
@@ -1,0 +1,50 @@
+"""Crée le modèle Wagtail Page `StaticContentPage`.
+
+Le modèle cohabite temporairement avec l'ancien snippet `StaticPage` ; la
+data migration 0004 recopiera le contenu, puis 0005 supprimera le snippet.
+"""
+
+import django.db.models.deletion
+import wagtail.fields
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pages", "0002_seed_static_pages"),
+        ("wagtailcore", "0094_alter_page_locale"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="StaticContentPage",
+            fields=[
+                (
+                    "page_ptr",
+                    models.OneToOneField(
+                        auto_created=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        parent_link=True,
+                        primary_key=True,
+                        serialize=False,
+                        to="wagtailcore.page",
+                    ),
+                ),
+                ("body", wagtail.fields.RichTextField(blank=True, verbose_name="Contenu")),
+            ],
+            options={
+                "verbose_name": "Page statique",
+                "verbose_name_plural": "Pages statiques",
+            },
+            bases=("wagtailcore.page",),
+        ),
+        migrations.AlterModelOptions(
+            name="staticpage",
+            options={
+                "ordering": ["slug"],
+                "verbose_name": "Page statique (legacy)",
+                "verbose_name_plural": "Pages statiques (legacy)",
+            },
+        ),
+    ]

--- a/backend/pages/migrations/0004_migrate_staticpages_to_pages.py
+++ b/backend/pages/migrations/0004_migrate_staticpages_to_pages.py
@@ -1,0 +1,72 @@
+"""Migre les `StaticPage` (snippets) vers des `StaticContentPage` (Page Wagtail).
+
+Pour chaque snippet existant, on crée une `StaticContentPage` enfant direct
+de la `HomePage`, avec le même slug, titre et contenu. Les slugs des deux
+pages seedées (`a-propos`, `mentions-legales`) sont conservés tels quels :
+le frontend Next.js les référence en dur.
+
+La migration est idempotente : si une `StaticContentPage` portant le même
+slug existe déjà sous la `HomePage`, le snippet correspondant est ignoré.
+"""
+
+from django.db import migrations
+
+
+def migrate_static_pages_to_pages(apps, schema_editor):
+    StaticPage = apps.get_model("pages", "StaticPage")
+
+    # La manipulation d'arbre Wagtail (add_child, MP_Node) requiert les
+    # modèles runtime, pas ceux retournés par apps.get_model.
+    from home.models import HomePage as RuntimeHomePage
+    from pages.models import StaticContentPage as RuntimeStaticContentPage
+
+    home = RuntimeHomePage.objects.first()
+    if home is None:
+        return
+
+    existing_slugs = set(
+        RuntimeStaticContentPage.objects.descendant_of(home)
+        .values_list("slug", flat=True)
+    )
+
+    for snippet in StaticPage.objects.all().order_by("slug"):
+        if snippet.slug in existing_slugs:
+            continue
+
+        page = RuntimeStaticContentPage(
+            title=snippet.title,
+            slug=snippet.slug,
+            body=snippet.body,
+            live=snippet.live,
+            has_unpublished_changes=snippet.has_unpublished_changes,
+            first_published_at=snippet.first_published_at,
+            last_published_at=snippet.last_published_at,
+        )
+        home.add_child(instance=page)
+        existing_slugs.add(snippet.slug)
+
+        # Crée une révision initiale pour que l'historique de publication
+        # soit lisible dans l'admin Wagtail.
+        if snippet.live:
+            page.save_revision().publish()
+        else:
+            page.save_revision()
+
+
+def reverse_migrate(apps, schema_editor):
+    from pages.models import StaticContentPage as RuntimeStaticContentPage
+
+    for page in list(RuntimeStaticContentPage.objects.all()):
+        page.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pages", "0003_create_staticcontentpage"),
+        ("home", "0003_seed_home_page"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_static_pages_to_pages, reverse_code=reverse_migrate),
+    ]

--- a/backend/pages/migrations/0005_remove_staticpage_snippet.py
+++ b/backend/pages/migrations/0005_remove_staticpage_snippet.py
@@ -1,0 +1,21 @@
+"""Supprime l'ancien snippet `StaticPage`.
+
+À jouer après la data migration 0004 qui a recopié le contenu dans des
+`StaticContentPage`. Plus aucun code de l'application ne référence le
+snippet après cette migration.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pages", "0004_migrate_staticpages_to_pages"),
+    ]
+
+    operations = [
+        migrations.DeleteModel(
+            name="StaticPage",
+        ),
+    ]

--- a/backend/pages/models.py
+++ b/backend/pages/models.py
@@ -1,38 +1,22 @@
-from django.db import models
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
-from wagtail.models import DraftStateMixin, RevisionMixin
-from wagtail.snippets.models import register_snippet
+from wagtail.models import Page
 
 
-class StaticPageSlug(models.TextChoices):
-    MENTIONS_LEGALES = "mentions-legales", "Mentions légales"
-    A_PROPOS = "a-propos", "À propos"
+class StaticContentPage(Page):
+    """Page statique éditable depuis Wagtail (À propos, Mentions légales, etc.)."""
 
-
-@register_snippet
-class StaticPage(DraftStateMixin, RevisionMixin, models.Model):
-    slug = models.SlugField(
-        "Identifiant",
-        max_length=64,
-        unique=True,
-        choices=StaticPageSlug.choices,
-        help_text="Identifie la page côté frontend (ne pas modifier).",
-    )
-    title = models.CharField("Titre", max_length=255)
     body = RichTextField("Contenu", blank=True)
-    updated_at = models.DateTimeField(auto_now=True)
 
-    panels = [
-        FieldPanel("slug", read_only=True),
-        FieldPanel("title"),
+    content_panels = Page.content_panels + [
         FieldPanel("body"),
     ]
+
+    parent_page_types = ["home.HomePage"]
+    subpage_types = []
+
+    preview_modes = []
 
     class Meta:
         verbose_name = "Page statique"
         verbose_name_plural = "Pages statiques"
-        ordering = ["slug"]
-
-    def __str__(self):
-        return self.get_slug_display()

--- a/backend/pages/tests/test_pages.py
+++ b/backend/pages/tests/test_pages.py
@@ -4,7 +4,7 @@ import pytest
 from django.http import Http404
 from django.test import RequestFactory
 
-from pages.models import StaticPage
+from pages.models import StaticContentPage
 from pages.views import static_page_detail
 
 pytestmark = pytest.mark.django_db
@@ -32,16 +32,15 @@ class TestStaticPageDetailEndpoint:
             static_page_detail(request, slug="inexistante")
 
     def test_returns_404_when_page_unpublished(self, rf):
-        page = StaticPage.objects.get(slug="a-propos")
+        page = StaticContentPage.objects.get(slug="a-propos")
         page.unpublish()
-        page.save()
 
         request = rf.get("/api/pages/a-propos/")
         with pytest.raises(Http404):
             static_page_detail(request, slug="a-propos")
 
     def test_empty_body_returns_empty_string(self, rf):
-        page = StaticPage.objects.get(slug="a-propos")
+        page = StaticContentPage.objects.get(slug="a-propos")
         page.body = ""
         page.save()
 
@@ -57,7 +56,7 @@ class TestStaticPageDetailEndpoint:
         assert response.status_code == 405
 
     def test_body_is_rendered_html(self, rf):
-        page = StaticPage.objects.get(slug="mentions-legales")
+        page = StaticContentPage.objects.get(slug="mentions-legales")
         page.body = "<p>Hello <strong>world</strong></p>"
         page.save()
 
@@ -71,10 +70,19 @@ class TestSeedDataMigration:
     """Verify the data migration created the two expected pages."""
 
     def test_seeded_pages_exist(self):
-        assert StaticPage.objects.filter(slug="mentions-legales").exists()
-        assert StaticPage.objects.filter(slug="a-propos").exists()
+        assert StaticContentPage.objects.filter(slug="mentions-legales").exists()
+        assert StaticContentPage.objects.filter(slug="a-propos").exists()
 
     def test_seeded_pages_are_live(self):
         for slug in ("mentions-legales", "a-propos"):
-            page = StaticPage.objects.get(slug=slug)
+            page = StaticContentPage.objects.get(slug=slug)
             assert page.live is True
+
+    def test_seeded_pages_are_children_of_home(self):
+        from home.models import HomePage
+
+        home = HomePage.objects.first()
+        assert home is not None
+        for slug in ("mentions-legales", "a-propos"):
+            page = StaticContentPage.objects.get(slug=slug)
+            assert page.get_parent().specific == home

--- a/backend/pages/views.py
+++ b/backend/pages/views.py
@@ -2,15 +2,15 @@ from django.http import Http404, JsonResponse
 from django.views.decorators.http import require_GET
 from wagtail.rich_text import expand_db_html
 
-from .models import StaticPage
+from .models import StaticContentPage
 
 
 @require_GET
 def static_page_detail(request, slug):
     """Return a published static page as JSON."""
     try:
-        page = StaticPage.objects.get(slug=slug, live=True)
-    except StaticPage.DoesNotExist as exc:
+        page = StaticContentPage.objects.live().get(slug=slug)
+    except StaticContentPage.DoesNotExist as exc:
         raise Http404("Page introuvable") from exc
 
     return JsonResponse(

--- a/frontend/app/a-propos/page.tsx
+++ b/frontend/app/a-propos/page.tsx
@@ -4,6 +4,8 @@ export const metadata: Metadata = {
   title: 'À propos',
 };
 
+export const dynamic = 'force-dynamic';
+
 const API_URL =
   process.env.INTERNAL_API_URL ||
   process.env.NEXT_PUBLIC_API_URL ||

--- a/frontend/app/mentions-legales/page.tsx
+++ b/frontend/app/mentions-legales/page.tsx
@@ -4,6 +4,8 @@ export const metadata: Metadata = {
   title: 'Mentions légales',
 };
 
+export const dynamic = 'force-dynamic';
+
 const API_URL =
   process.env.INTERNAL_API_URL ||
   process.env.NEXT_PUBLIC_API_URL ||


### PR DESCRIPTION
## Pourquoi

- **Cohérence** avec le reste de l'arbre Wagtail. `BlogIndexPage`/`ArticlePage` et `ProjectsIndexPage`/`ProjectPage` sont déjà des Pages — les pages statiques étaient les seules à rester sur le pattern Snippet.
- **Corrige le bug** « les modifs de "À propos" / "Mentions légales" depuis Wagtail ne s'affichent pas sur le site » : la route Next.js était figée au build. Cause : `INTERNAL_API_URL` n'est pas défini au build, donc `fetchStaticPage` retournait `null` avant d'appeler `fetch()` → Next.js ne voyait aucun signal dynamique → la route était pré-rendue statiquement avec le fallback.

## Changements

### Backend
- Nouveau modèle `StaticContentPage(Page)` (parent unique : `HomePage`, panel `body` RichTextField).
- `0003_create_staticcontentpage` : schéma.
- `0004_migrate_staticpages_to_pages` : data migration **idempotente** — pour chaque snippet, crée une `StaticContentPage` enfant de `HomePage` avec le même slug (`a-propos`, `mentions-legales`), titre, body et état `live`, puis publie une révision initiale.
- `0005_remove_staticpage_snippet` : `DeleteModel("StaticPage")`.
- `pages/views.py` : `static_page_detail` query maintenant `StaticContentPage.objects.live().get(slug=slug)`.
- Tests adaptés + nouveau test : les pages seedées sont bien enfants de `HomePage`.

### Frontend
- `frontend/app/a-propos/page.tsx` et `frontend/app/mentions-legales/page.tsx` : `export const dynamic = 'force-dynamic';` pour forcer le SSR à chaque requête (le fix du bug initial).

## Notes pour la review

- **Nom du modèle** : `StaticContentPage` plutôt que `StaticPage` car le snippet existant occupait déjà ce nom — il fallait une cohabitation transitoire pour la data migration. Si tu préfères `StaticPage` final, on peut ajouter une migration `RenameModel` après ce PR.
- **Slugs figés par convention**, pas par contrainte technique : les slugs `a-propos` et `mentions-legales` sont seedés par la data migration ; rien n'empêche un éditeur de les modifier ensuite — mais le frontend les référence en dur, donc on compte sur la convention.
- **Le snippet legacy disparaît** de l'admin Wagtail après cette migration. Aucun risque de perte de données : la 0004 copie tout, la 0005 supprime ensuite.

## Tests

- Tests `pages/` : 9/9 ✅ (incluant nouveau test sur la hiérarchie).
- Suite complète : 104/106 ✅. Les 2 échecs (`blog::test_ordered_newest_first`, `projects::test_ordering_newest_first`) sont **pré-existants et non liés** à ce PR — issue de timing SQLite sur `timezone.now()` dans des tests de tri.
- Migrations testées sur DB neuve : `migrate` 5/5 OK, `makemigrations --check` clean.

## Test plan

- [ ] Login admin Wagtail → Pages → `home` → vérifier que « À propos » et « Mentions légales » apparaissent comme `Static content page`.
- [ ] Modifier le contenu de « À propos », cliquer **Publier**.
- [ ] Vérifier que la modif apparaît immédiatement sur `/a-propos` côté frontend (pareil pour `/mentions-legales`).
- [ ] Vérifier qu'aucune ancienne « Page statique » (legacy snippet) ne traîne dans l'onglet Snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)