### PR TITLE
fix(middleware): exclure /api/pages/ du LoginRequiredMiddleware

### DIFF
--- a/backend/config/middleware.py
+++ b/backend/config/middleware.py
@@ -13,6 +13,10 @@ class LoginRequiredMiddleware:
     - /admin/        → Wagtail admin (has its own auth)
     - /django-admin/ → Django admin (has its own auth)
     - /api/auth/     → Auth endpoints (must be accessible to log in)
+    - /api/pages/    → Pages statiques publiques (À propos, Mentions légales).
+                      Lues en SSR par Next.js sans cookies de session — un
+                      blocage ici renvoie une page vide aux utilisateurs
+                      authentifiés.
     - /static/       → Static files
     - /media/        → Media files
     """
@@ -21,6 +25,7 @@ class LoginRequiredMiddleware:
         "/admin/",
         "/django-admin/",
         "/api/auth/",
+        "/api/pages/",
         "/api/preview/",
         "/documents/",
         "/static/",

--- a/backend/home/tests/test_middleware.py
+++ b/backend/home/tests/test_middleware.py
@@ -33,6 +33,8 @@ class TestLoginRequiredMiddleware:
         "/django-admin/",
         "/api/auth/check/",
         "/api/auth/login/",
+        "/api/pages/a-propos/",
+        "/api/pages/mentions-legales/",
         "/static/test.css",
         "/media/test.jpg",
     ])


### PR DESCRIPTION
## Symptôme

En prod (mode « site en construction » → `SiteSettings.require_authentication=True`), les pages `/a-propos` et `/mentions-legales` apparaissent vides — **même pour les utilisateurs authentifiés**. L'admin Wagtail montre bien le contenu publié, mais le frontend ne l'affiche pas.

## Cause

Les routes [`a-propos/page.tsx`](frontend/app/a-propos/page.tsx) et [`mentions-legales/page.tsx`](frontend/app/mentions-legales/page.tsx) sont des **Server Components** (`force-dynamic`). Le `fetch` vers `/api/pages/<slug>/` part **côté serveur** Next.js (server-to-server) et n'embarque donc pas les cookies de session du navigateur.

Du coup :
1. Django reçoit une requête anonyme
2. `LoginRequiredMiddleware` voit que `require_authentication=True` et que `/api/pages/` n'est pas dans `EXCLUDED_PREFIXES` → **401**
3. `fetchStaticPage` retourne `null` → page rendue avec juste le titre fallback

C'est exactement le scénario décrit dans la mémoire projet sur ce middleware (« tout marche en isolation, échoue cross-service »).

## Fix

Ajout de `/api/pages/` à `EXCLUDED_PREFIXES`. Justifications :

- **Pages publiques par nature** : mentions légales = obligation légale d'accès public, « À propos » = contenu vitrine.
- **Aucune fuite** : l'API ne retourne que `live=True`.
- **Pas de régression sur le mode construction** : le middleware **Next.js** continue de rediriger les visiteurs anonymes vers `/login` sur les routes navigateur. Seule l'API JSON devient atteignable directement (pour le SSR Next.js, qui en avait besoin).
- **Cohérent avec `/api/preview/`** déjà exclu pour la même raison (endpoint sans session, auth alternative).

## Tests

Test paramétrisé enrichi dans `home/tests/test_middleware.py` : `/api/pages/a-propos/` et `/api/pages/mentions-legales/` ne doivent pas renvoyer 401 même quand `require_authentication=True`.

Tous les tests passent localement (20/20 sur `home/tests/test_middleware.py` + `pages/tests/test_pages.py`).

## Test plan

- [ ] Merger + déployer
- [ ] Avec un compte connecté en prod, ouvrir https://cultur-all.org/a-propos → contenu visible
- [ ] Idem pour https://cultur-all.org/mentions-legales
- [ ] Vérifier qu'un visiteur anonyme est toujours redirigé vers `/login` quand il ouvre `/a-propos` (pas de régression sur le mode construction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)