### PR TITLE
feat(projets): paginer la liste avec un bouton "Afficher plus"

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -354,6 +354,12 @@ body {
   gap: 1.5rem;
 }
 
+.projets-page__load-more {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
 /* Tag filters */
 .projects-filters {
   display: flex;

--- a/frontend/app/projets/page.tsx
+++ b/frontend/app/projets/page.tsx
@@ -5,11 +5,13 @@ import Link from 'next/link';
 import { Project } from '../types/project';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
+const PAGE_SIZE = 20;
 
 export default function ProjetsPage() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -39,6 +41,12 @@ export default function ProjetsPage() {
     () => selectedTag ? projects.filter((p) => p.tags.includes(selectedTag)) : projects,
     [projects, selectedTag],
   );
+  const visible = filtered.slice(0, visibleCount);
+  const hasMore = filtered.length > visibleCount;
+
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [selectedTag]);
 
   return (
     <div className="page projets-page">
@@ -69,8 +77,9 @@ export default function ProjetsPage() {
       ) : filtered.length === 0 ? (
         <p className="projets-page__message">Aucun projet pour le moment.</p>
       ) : (
+        <>
         <div className="projets-grid" key={selectedTag ?? '__all__'}>
-          {filtered.map((project, i) => (
+          {visible.map((project, i) => (
             <Link
               key={project.id}
               href={`/projets/${project.slug}`}
@@ -94,6 +103,18 @@ export default function ProjetsPage() {
             </Link>
           ))}
         </div>
+        {hasMore && (
+          <div className="projets-page__load-more">
+            <button
+              type="button"
+              className="projects-filters__btn"
+              onClick={() => setVisibleCount((n) => n + PAGE_SIZE)}
+            >
+              Afficher plus
+            </button>
+          </div>
+        )}
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

- Affiche les 20 premiers projets au chargement de `/projets`, avec un bouton **"Afficher plus"** qui charge les 20 suivants à chaque clic.
- La pagination est appliquée **après** le filtre par tag : changer de tag (ou revenir sur "Tous") réinitialise la fenêtre aux 20 premiers du sous-ensemble filtré.
- Pagination 100 % côté client : aucun changement backend, les `allTags` restent calculés sur l'ensemble des projets.

## Changes

- [frontend/app/projets/page.tsx](frontend/app/projets/page.tsx) : ajout d'un state `visibleCount` (initialisé à `PAGE_SIZE = 20`), slice de `filtered` pour la grille, `useEffect` qui reset `visibleCount` quand `selectedTag` change, bouton "Afficher plus" affiché tant que `filtered.length > visibleCount`.
- [frontend/app/globals.css](frontend/app/globals.css) : style `.projets-page__load-more` (centrage + marge).

## Test plan

- [ ] Avec > 20 projets : seuls les 20 premiers sont visibles au chargement, le bouton "Afficher plus" apparaît, le clic ajoute 20 projets de plus.
- [ ] Le bouton disparaît quand tous les projets sont affichés.
- [ ] Sélectionner un tag : la grille se réinitialise aux 20 premiers projets du tag, le bouton réapparaît si > 20 dans le tag.
- [ ] Cliquer "Tous" : retour aux 20 premiers projets globaux.
- [ ] Avec ≤ 20 projets : aucun bouton n'apparaît (comportement identique à avant).

Fixes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)