### PR TITLE
feat(static-pages): largeur max alignée et preview headless

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -11,7 +11,7 @@ from blog.views import article_detail, article_list, article_preview_draft
 from home.auth_views import auth_check, auth_login, auth_logout
 from home.views import contact_submit
 from network.views import network_member_list
-from pages.views import static_page_detail
+from pages.views import static_page_detail, static_page_preview_draft
 from projects.views import project_detail, project_featured, project_list, project_preview_draft
 
 
@@ -51,6 +51,7 @@ urlpatterns = [
     path("api/blog/articles/<slug:slug>/", article_detail, name="article-detail"),
     path("api/preview/article/", article_preview_draft, name="article-preview-draft"),
     path("api/preview/project/", project_preview_draft, name="project-preview-draft"),
+    path("api/preview/page/", static_page_preview_draft, name="static-page-preview-draft"),
     path("api/pages/<slug:slug>/", static_page_detail, name="static-page-detail"),
 
     # Catch-all Wagtail (page tree) — désactivé : on est headless, Next.js

--- a/backend/pages/models.py
+++ b/backend/pages/models.py
@@ -1,9 +1,10 @@
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page
+from wagtail_headless_preview.models import HeadlessPreviewMixin
 
 
-class StaticContentPage(Page):
+class StaticContentPage(HeadlessPreviewMixin, Page):
     """Page statique éditable depuis Wagtail (À propos, Mentions légales, etc.)."""
 
     body = RichTextField("Contenu", blank=True)
@@ -14,8 +15,6 @@ class StaticContentPage(Page):
 
     parent_page_types = ["home.HomePage"]
     subpage_types = []
-
-    preview_modes = []
 
     class Meta:
         verbose_name = "Page statique"

--- a/backend/pages/tests/test_pages.py
+++ b/backend/pages/tests/test_pages.py
@@ -5,7 +5,7 @@ from django.http import Http404
 from django.test import RequestFactory
 
 from pages.models import StaticContentPage
-from pages.views import static_page_detail
+from pages.views import static_page_detail, static_page_preview_draft
 
 pytestmark = pytest.mark.django_db
 
@@ -86,3 +86,53 @@ class TestSeedDataMigration:
         for slug in ("mentions-legales", "a-propos"):
             page = StaticContentPage.objects.get(slug=slug)
             assert page.get_parent().specific == home
+
+
+class TestStaticPagePreviewDraftEndpoint:
+    def test_returns_draft_content_with_valid_token(self, rf):
+        page = StaticContentPage.objects.get(slug="a-propos")
+        page.body = "<p>Brouillon non publié</p>"
+        page_preview = page.create_page_preview()
+        page_preview.save()
+
+        request = rf.get("/api/preview/page/", {"token": page_preview.token})
+        response = static_page_preview_draft(request)
+
+        assert response.status_code == 200
+        data = json.loads(response.content)
+        assert data["slug"] == "a-propos"
+        assert "Brouillon non publié" in data["body"]
+
+    def test_returns_draft_for_unpublished_page(self, rf):
+        page = StaticContentPage.objects.get(slug="a-propos")
+        page.unpublish()
+        page.body = "<p>Modifs sur page dépubliée</p>"
+        page_preview = page.create_page_preview()
+        page_preview.save()
+
+        request = rf.get("/api/preview/page/", {"token": page_preview.token})
+        response = static_page_preview_draft(request)
+        data = json.loads(response.content)
+
+        assert data["slug"] == "a-propos"
+        assert "Modifs sur page dépubliée" in data["body"]
+
+    def test_missing_token_raises_404(self, rf):
+        request = rf.get("/api/preview/page/")
+        with pytest.raises(Http404):
+            static_page_preview_draft(request)
+
+    def test_invalid_token_raises_404(self, rf):
+        request = rf.get("/api/preview/page/", {"token": "token-invalide"})
+        with pytest.raises(Http404):
+            static_page_preview_draft(request)
+
+    def test_tampered_token_raises_404(self, rf):
+        page = StaticContentPage.objects.get(slug="a-propos")
+        page_preview = page.create_page_preview()
+        page_preview.save()
+
+        tampered = page_preview.token + "tampered"
+        request = rf.get("/api/preview/page/", {"token": tampered})
+        with pytest.raises(Http404):
+            static_page_preview_draft(request)

--- a/backend/pages/views.py
+++ b/backend/pages/views.py
@@ -5,6 +5,14 @@ from wagtail.rich_text import expand_db_html
 from .models import StaticContentPage
 
 
+def _serialize(page):
+    return {
+        "slug": page.slug,
+        "title": page.title,
+        "body": expand_db_html(page.body) if page.body else "",
+    }
+
+
 @require_GET
 def static_page_detail(request, slug):
     """Return a published static page as JSON."""
@@ -13,10 +21,28 @@ def static_page_detail(request, slug):
     except StaticContentPage.DoesNotExist as exc:
         raise Http404("Page introuvable") from exc
 
-    return JsonResponse(
-        {
-            "slug": page.slug,
-            "title": page.title,
-            "body": expand_db_html(page.body) if page.body else "",
-        }
-    )
+    return JsonResponse(_serialize(page))
+
+
+@require_GET
+def static_page_preview_draft(request):
+    """Retourne les données brouillon d'une StaticContentPage pour la preview headless.
+
+    Authentifié par token signé (créé par wagtail-headless-preview lors du clic Aperçu).
+    Le token fait office de credential — aucune session Django requise.
+    """
+    from django.core.signing import BadSignature
+
+    token = request.GET.get("token")
+    if not token:
+        raise Http404("Token manquant")
+
+    try:
+        page = StaticContentPage.get_page_from_preview_token(token)
+    except BadSignature:
+        raise Http404("Token invalide")
+
+    if page is None:
+        raise Http404("Token introuvable ou expiré")
+
+    return JsonResponse(_serialize(page))

--- a/frontend/app/a-propos/page.tsx
+++ b/frontend/app/a-propos/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import StaticPageContent from '../components/StaticPageContent';
 
 export const metadata: Metadata = {
   title: 'À propos',
@@ -6,41 +7,16 @@ export const metadata: Metadata = {
 
 export const dynamic = 'force-dynamic';
 
-const API_URL =
-  process.env.INTERNAL_API_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  '';
-
-const FALLBACK_TITLE = 'À propos';
-
-type StaticPage = {
-  slug: string;
-  title: string;
-  body: string;
+type Props = {
+  searchParams: { preview_token?: string };
 };
 
-async function fetchStaticPage(slug: string): Promise<StaticPage | null> {
-  if (!API_URL) return null;
-  try {
-    const res = await fetch(`${API_URL}/api/pages/${slug}/`, {
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as StaticPage;
-  } catch {
-    return null;
-  }
-}
-
-export default async function APropos() {
-  const page = await fetchStaticPage('a-propos');
-
+export default function APropos({ searchParams }: Props) {
   return (
-    <main className="page">
-      <h1>{page?.title ?? FALLBACK_TITLE}</h1>
-      {page?.body && (
-        <div dangerouslySetInnerHTML={{ __html: page.body }} />
-      )}
-    </main>
+    <StaticPageContent
+      slug="a-propos"
+      fallbackTitle="À propos"
+      previewToken={searchParams.preview_token}
+    />
   );
 }

--- a/frontend/app/components/StaticPageContent.tsx
+++ b/frontend/app/components/StaticPageContent.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+
+const API_URL =
+  process.env.INTERNAL_API_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  '';
+
+type StaticPage = {
+  slug: string;
+  title: string;
+  body: string;
+};
+
+async function fetchStaticPage(
+  slug: string,
+  previewToken?: string,
+): Promise<StaticPage | null> {
+  if (!API_URL) return null;
+  const url = previewToken
+    ? `${API_URL}/api/preview/page/?token=${encodeURIComponent(previewToken)}`
+    : `${API_URL}/api/pages/${slug}/`;
+  try {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) return null;
+    return (await res.json()) as StaticPage;
+  } catch {
+    return null;
+  }
+}
+
+type Props = {
+  slug: string;
+  fallbackTitle: string;
+  previewToken?: string;
+};
+
+export default async function StaticPageContent({
+  slug,
+  fallbackTitle,
+  previewToken,
+}: Props) {
+  const page = await fetchStaticPage(slug, previewToken);
+
+  return (
+    <main className="page">
+      {previewToken && (
+        <div className="preview-banner" role="status">
+          <span>Mode aperçu — ce contenu n&apos;est pas encore publié</span>
+          <Link href={`/${slug}`} className="preview-banner__exit">
+            Quitter l&apos;aperçu
+          </Link>
+        </div>
+      )}
+      <div className="static-page-wrapper">
+        <h1>{page?.title ?? fallbackTitle}</h1>
+        {page?.body && (
+          <div dangerouslySetInnerHTML={{ __html: page.body }} />
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -485,7 +485,8 @@ body {
 
 /* Project / article detail page (shared) */
 .project-detail-wrapper,
-.article-detail-wrapper {
+.article-detail-wrapper,
+.static-page-wrapper {
   max-width: 880px;
   margin: 0 auto;
 }

--- a/frontend/app/mentions-legales/page.tsx
+++ b/frontend/app/mentions-legales/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import StaticPageContent from '../components/StaticPageContent';
 
 export const metadata: Metadata = {
   title: 'Mentions légales',
@@ -6,41 +7,16 @@ export const metadata: Metadata = {
 
 export const dynamic = 'force-dynamic';
 
-const API_URL =
-  process.env.INTERNAL_API_URL ||
-  process.env.NEXT_PUBLIC_API_URL ||
-  '';
-
-const FALLBACK_TITLE = 'Mentions légales';
-
-type StaticPage = {
-  slug: string;
-  title: string;
-  body: string;
+type Props = {
+  searchParams: { preview_token?: string };
 };
 
-async function fetchStaticPage(slug: string): Promise<StaticPage | null> {
-  if (!API_URL) return null;
-  try {
-    const res = await fetch(`${API_URL}/api/pages/${slug}/`, {
-      cache: 'no-store',
-    });
-    if (!res.ok) return null;
-    return (await res.json()) as StaticPage;
-  } catch {
-    return null;
-  }
-}
-
-export default async function MentionsLegales() {
-  const page = await fetchStaticPage('mentions-legales');
-
+export default function MentionsLegales({ searchParams }: Props) {
   return (
-    <main className="page">
-      <h1>{page?.title ?? FALLBACK_TITLE}</h1>
-      {page?.body && (
-        <div dangerouslySetInnerHTML={{ __html: page.body }} />
-      )}
-    </main>
+    <StaticPageContent
+      slug="mentions-legales"
+      fallbackTitle="Mentions légales"
+      previewToken={searchParams.preview_token}
+    />
   );
 }

--- a/frontend/app/preview/route.ts
+++ b/frontend/app/preview/route.ts
@@ -3,15 +3,19 @@ import { NextRequest, NextResponse } from 'next/server';
 const INTERNAL_API_URL =
   process.env.INTERNAL_API_URL || process.env.NEXT_PUBLIC_API_URL || 'http://django:8000';
 
-// Dispatch table : content_type → endpoint backend draft + préfixe de route frontend
-const PREVIEW_ROUTES: Record<string, { backendPath: string; frontendPrefix: string }> = {
+// Dispatch table : content_type → endpoint backend draft + builder de chemin frontend
+const PREVIEW_ROUTES: Record<string, { backendPath: string; buildPath: (slug: string) => string }> = {
   'blog.articlepage': {
     backendPath: '/api/preview/article/',
-    frontendPrefix: '/blog',
+    buildPath: (slug) => `/blog/${slug}`,
   },
   'projects.projectpage': {
     backendPath: '/api/preview/project/',
-    frontendPrefix: '/projets',
+    buildPath: (slug) => `/projets/${slug}`,
+  },
+  'pages.staticcontentpage': {
+    backendPath: '/api/preview/page/',
+    buildPath: (slug) => `/${slug}`,
   },
 };
 
@@ -40,7 +44,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'content_type non supporté' }, { status: 400 });
   }
 
-  const { backendPath, frontendPrefix } = PREVIEW_ROUTES[contentType];
+  const { backendPath, buildPath } = PREVIEW_ROUTES[contentType];
 
   let res: Response;
   try {
@@ -59,7 +63,7 @@ export async function GET(request: NextRequest) {
   const data = await res.json();
   const slug: string = data.slug;
 
-  const previewUrl = new URL(`${frontendPrefix}/${slug}`, getExternalBaseUrl(request));
+  const previewUrl = new URL(buildPath(slug), getExternalBaseUrl(request));
   previewUrl.searchParams.set('preview_token', token);
   previewUrl.searchParams.set('content_type', contentType);
 


### PR DESCRIPTION
## Pourquoi

Aligner les pages statiques (À propos, Mentions légales) sur l'expérience des articles de blog et projets, à la fois côté **rendu** (largeur) et **édition** (preview).

## Changements

### Mise en page
- Ajout de la classe `.static-page-wrapper` partagée avec `.article-detail-wrapper` / `.project-detail-wrapper` (`max-width: 880px; margin: 0 auto;`).
- Le contenu de `/a-propos` et `/mentions-legales` est désormais centré sur la même largeur que les articles et projets.

### Preview headless dans Wagtail
- `StaticContentPage` hérite de `HeadlessPreviewMixin` — l'éditeur dispose maintenant du bouton **« Aperçu »** dans le formulaire d'édition des pages statiques.
- Nouvel endpoint backend [`/api/preview/page/`](backend/pages/views.py) (token signé, même pattern que `/api/preview/article/` et `/api/preview/project/`).
- Le route handler [`/preview`](frontend/app/preview/route.ts) dispatche `pages.staticcontentpage` vers la bonne URL frontend. Le slug pointe directement à la racine (`/a-propos`, `/mentions-legales`) plutôt que `/blog/<slug>` ou `/projets/<slug>`.
- Les pages [`/a-propos`](frontend/app/a-propos/page.tsx) et [`/mentions-legales`](frontend/app/mentions-legales/page.tsx) lisent `?preview_token=…` via `searchParams` (Server Component), basculent sur l'endpoint preview et affichent le bandeau « Mode aperçu » (réutilise `.preview-banner`).

### Refactoring
- La logique commune des deux pages est extraite dans le composant [`<StaticPageContent>`](frontend/app/components/StaticPageContent.tsx) (props : `slug`, `fallbackTitle`, `previewToken`).

## Notes

- Pas de migration nécessaire : `HeadlessPreviewMixin` n'ajoute aucun champ (vérifié via `makemigrations --check` → « No changes detected »).
- L'endpoint `/api/preview/page/` est déjà couvert par le préfixe `/api/preview/` dans `EXCLUDED_PREFIXES` du `LoginRequiredMiddleware` (le token signé fait office d'auth).

## Tests

- Suite `pages/tests/` : 14/14 ✅, dont 5 nouveaux tests pour l'endpoint preview (token valide, brouillon non publié, token manquant/invalide/altéré).
- `home/tests/test_middleware.py` : 11/11 ✅.
- Smoke test manuel sur la stack dev locale :
  - `/api/pages/a-propos/` → 200 ✓
  - `/api/preview/page/?token=<valide>` → 200 avec brouillon ✓
  - `/preview?token=…&content_type=pages.staticcontentpage` → 307 vers `/a-propos?preview_token=…` ✓
  - HTML rendu contient bien `.static-page-wrapper` (toujours) et `.preview-banner` (uniquement avec token) ✓

## Test plan

- [ ] Login admin Wagtail → ouvrir « À propos » dans Pages → cliquer **Aperçu** → vérifier que la page de preview s'ouvre dans un nouvel onglet avec le bandeau « Mode aperçu » en haut.
- [ ] Modifier le `body` sans publier → re-cliquer Aperçu → vérifier que le brouillon s'affiche.
- [ ] Quitter le mode aperçu (lien « Quitter l'aperçu ») → revient sur `/a-propos` sans paramètre.
- [ ] Vérifier visuellement que `/a-propos` et `/mentions-legales` ont bien le même padding/largeur que `/blog/<slug>` et `/projets/<slug>`.
- [ ] Idem pour `Mentions légales`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)