### PR TITLE
fix(blog): cap card width at 350px and shorten excerpt to 200 chars

### DIFF
--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { Article } from '../types/article';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
-const EXCERPT_LENGTH = 500;
+const EXCERPT_LENGTH = 200;
 
 function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, '');

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -963,15 +963,19 @@ body {
 }
 
 .blog-masonry {
-  columns: 3 300px;
-  column-gap: 1.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
+  gap: 1.5rem;
+  /* Cap at 5 cards per row: 5 * 350px + 4 * 1.5rem gap */
+  max-width: calc(5 * 350px + 4 * 1.5rem);
+  margin-inline: auto;
 }
 
 .blog-card {
   display: block;
   width: 100%;
-  break-inside: avoid;
-  margin-bottom: 1.5rem;
+  max-width: 350px;
+  justify-self: center;
   background: rgba(255, 255, 255, 0.05);
   border: none;
   border-radius: 0.5rem;
@@ -1154,11 +1158,6 @@ body {
 
   .carousel-card {
     flex: 0 0 180px;
-  }
-
-  /* Blog page mobile */
-  .blog-masonry {
-    columns: 1;
   }
 
   .site-footer__content {


### PR DESCRIPTION
## Summary
- Replace masonry `columns` layout on `/blog` with a responsive CSS grid (`repeat(auto-fill, minmax(280px, 1fr))`) capped at **5 cards per row** via a container `max-width` (5 × 350px + 4 × gap).
- Constrain each card to **350px max width** so cards never grow past that on large screens.
- Shorten article preview from **500 → 200** characters.
- Drop the now-obsolete mobile override (`columns: 1`) — the grid handles small screens via `auto-fill`.

Fixes #147

## Test plan
- [ ] Visual check on small screen (≤ 600px): single column, cards readable.
- [ ] Visual check on medium screen (~1200px): 3–4 cards per row.
- [ ] Visual check on wide screen (≥ 1900px): max 5 cards per row, no card wider than 350px, container centered.
- [ ] Excerpts in card list are truncated at 200 chars with trailing `…`.
- [ ] Tag filter animation still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)