### PR TITLE
Revert #148: restore previous blog list layout

### DIFF
--- a/frontend/app/blog/page.tsx
+++ b/frontend/app/blog/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { Article } from '../types/article';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || '';
-const EXCERPT_LENGTH = 200;
+const EXCERPT_LENGTH = 500;
 
 function stripHtml(html: string): string {
   return html.replace(/<[^>]*>/g, '');

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -963,19 +963,15 @@ body {
 }
 
 .blog-masonry {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(min(100%, 280px), 1fr));
-  gap: 1.5rem;
-  /* Cap at 5 cards per row: 5 * 350px + 4 * 1.5rem gap */
-  max-width: calc(5 * 350px + 4 * 1.5rem);
-  margin-inline: auto;
+  columns: 3 300px;
+  column-gap: 1.5rem;
 }
 
 .blog-card {
   display: block;
   width: 100%;
-  max-width: 350px;
-  justify-self: center;
+  break-inside: avoid;
+  margin-bottom: 1.5rem;
   background: rgba(255, 255, 255, 0.05);
   border: none;
   border-radius: 0.5rem;
@@ -1158,6 +1154,11 @@ body {
 
   .carousel-card {
     flex: 0 0 180px;
+  }
+
+  /* Blog page mobile */
+  .blog-masonry {
+    columns: 1;
   }
 
   .site-footer__content {


### PR DESCRIPTION
## Summary
Revert of #148 (issue #147) — l'utilisateur préfère la mise en page précédente :
- Restore masonry `columns: 3 300px` layout for `/blog`.
- Restore `EXCERPT_LENGTH = 500`.
- Restore mobile override `columns: 1`.

Reverts merge commit `e44709c1`.

## Test plan
- [ ] Page `/blog` retrouve son layout d'origine (masonry).
- [ ] Aperçus à 500 caractères.

🤖 Generated with [Claude Code](https://claude.com/claude-code)