### PR TITLE
docs: add comparative study of Django+React vs Django+HTMX stack

### DIFF
--- a/backend/config/middleware.py
+++ b/backend/config/middleware.py
@@ -30,6 +30,9 @@ class LoginRequiredMiddleware:
         "/documents/",
         "/static/",
         "/media/",
+        # POC HTMX (cf. docs/poc-htmx-a-propos.md) : la page À propos
+        # rendue côté serveur reste publique, comme son équivalent API.
+        "/a-propos/",
     )
 
     def __init__(self, get_response):

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -74,7 +74,7 @@ ROOT_URLCONF = "config.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -82,6 +82,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "wagtail.contrib.settings.context_processors.settings",
             ],
         },
     },
@@ -107,6 +108,7 @@ USE_TZ = True
 # ─── Static / Media ────────────────────────────────────────────
 STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_DIRS = [BASE_DIR / "static"]
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -11,7 +11,7 @@ from blog.views import article_detail, article_list, article_preview_draft
 from home.auth_views import auth_check, auth_login, auth_logout
 from home.views import contact_submit
 from network.views import network_member_list
-from pages.views import static_page_detail, static_page_preview_draft
+from pages.views import static_page_detail, static_page_html, static_page_preview_draft
 from projects.views import project_detail, project_featured, project_list, project_preview_draft
 
 
@@ -37,6 +37,11 @@ urlpatterns = [
 
     # API
     path("api/contact/", contact_submit, name="contact-submit"),
+
+    # POC HTMX — rendu serveur Django/Wagtail pour la page À propos.
+    # Cf. docs/poc-htmx-a-propos.md. Ne remplace pas la route Next.js, vit
+    # à côté sur le port Django (8000) pour comparaison directe.
+    path("a-propos/", static_page_html, {"slug": "a-propos"}, name="static-page-html"),
 
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),

--- a/backend/pages/models.py
+++ b/backend/pages/models.py
@@ -1,10 +1,9 @@
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page
-from wagtail_headless_preview.models import HeadlessPreviewMixin
 
 
-class StaticContentPage(HeadlessPreviewMixin, Page):
+class StaticContentPage(Page):
     """Page statique éditable depuis Wagtail (À propos, Mentions légales, etc.)."""
 
     body = RichTextField("Contenu", blank=True)

--- a/backend/pages/templates/pages/static_content_page.html
+++ b/backend/pages/templates/pages/static_content_page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block title %}{{ page.title }} — Cultur'all{% endblock %}
+
+{% block content %}
+<main class="page">
+  <div class="static-page-wrapper">
+    <h1>{{ page.title }}</h1>
+    {% if page.body %}
+      <div>{{ page.body|richtext }}</div>
+    {% endif %}
+  </div>
+</main>
+{% endblock %}

--- a/backend/pages/tests/test_html_view.py
+++ b/backend/pages/tests/test_html_view.py
@@ -1,0 +1,64 @@
+"""POC HTMX — tests pour la page À propos rendue côté serveur.
+
+Cf. docs/poc-htmx-a-propos.md.
+"""
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+from pages.models import StaticContentPage
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client():
+    return Client()
+
+
+class TestStaticPageHtmlView:
+    def test_renders_seeded_a_propos_page(self, client):
+        response = client.get(reverse("static-page-html"))
+
+        assert response.status_code == 200
+        assert response["Content-Type"].startswith("text/html")
+        assert b"<title>" in response.content
+        assert "À propos" in response.content.decode()
+
+    def test_renders_body_as_html(self, client):
+        page = StaticContentPage.objects.get(slug="a-propos")
+        page.body = "<p>Bonjour <strong>monde</strong></p>"
+        page.save()
+
+        response = client.get(reverse("static-page-html"))
+        body = response.content.decode()
+
+        assert "<strong>monde</strong>" in body
+
+    def test_includes_header_and_footer(self, client):
+        response = client.get(reverse("static-page-html"))
+        body = response.content.decode()
+
+        assert 'class="header"' in body
+        assert "Nos Projets" in body
+        assert "Mentions légales" in body
+        assert 'class="site-footer"' in body
+
+    def test_returns_404_when_page_unpublished(self, client):
+        page = StaticContentPage.objects.get(slug="a-propos")
+        page.unpublish()
+
+        response = client.get(reverse("static-page-html"))
+        assert response.status_code == 404
+
+    def test_only_get_allowed(self, client):
+        response = client.post(reverse("static-page-html"))
+        assert response.status_code == 405
+
+    def test_loads_static_assets(self, client):
+        response = client.get(reverse("static-page-html"))
+        body = response.content.decode()
+
+        assert "/static/css/main.css" in body
+        assert "/static/js/site.js" in body

--- a/backend/pages/views.py
+++ b/backend/pages/views.py
@@ -1,4 +1,5 @@
 from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_GET
 from wagtail.rich_text import expand_db_html
 
@@ -22,6 +23,18 @@ def static_page_detail(request, slug):
         raise Http404("Page introuvable") from exc
 
     return JsonResponse(_serialize(page))
+
+
+@require_GET
+def static_page_html(request, slug):
+    """POC : rend la page statique côté serveur via un template Django/Wagtail.
+
+    Démontre la trajectoire de migration vers Django + HTMX décrite dans
+    docs/stack-comparison-django-react-vs-htmx.md. Coexiste avec la version
+    Next.js sans la remplacer : route ouverte uniquement sur /a-propos/.
+    """
+    page = get_object_or_404(StaticContentPage.objects.live(), slug=slug)
+    return render(request, "pages/static_content_page.html", {"page": page})
 
 
 @require_GET

--- a/backend/static/css/main.css
+++ b/backend/static/css/main.css
@@ -1,0 +1,1176 @@
+@keyframes filterCardIn {
+  from {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  color: #fff;
+  background: #000;
+}
+
+/* Header */
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 2rem;
+  z-index: 10;
+  background: transparent;
+  transition: background 0.3s ease;
+}
+
+.header--scrolled {
+  background: rgba(0, 0, 0, 0.85);
+}
+
+.header-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #fff;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+  display: flex;
+  align-items: center;
+}
+
+.header-logo {
+  height: 40px;
+  width: auto;
+  object-fit: contain;
+}
+
+.header-nav {
+  display: flex;
+  gap: 2rem;
+}
+
+.header-nav a,
+.header-nav__link {
+  color: #fff;
+  text-decoration: none;
+  font-size: 1rem;
+  font-weight: 500;
+  transition: opacity 0.2s;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  font-family: inherit;
+}
+
+.header-nav a:hover,
+.header-nav__link:hover {
+  opacity: 0.8;
+}
+
+/* Hamburger button — hidden on desktop, visible on mobile */
+.header-burger {
+  display: none;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0;
+  z-index: 12;
+}
+
+/* Landing page */
+.landing {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  height: 100vh;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.landing-video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
+  pointer-events: none;
+}
+
+.landing-video iframe {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 110vw;
+  height: 61.875vw; /* 16:9 ratio, scaled 110% */
+  min-height: 110vh;
+  min-width: 195.55vh; /* 16:9 ratio, scaled 110% */
+  transform: translate(-50%, -50%);
+  border: none;
+}
+
+/* Pages intérieures */
+.page {
+  min-height: 100vh;
+  padding: 6rem 2rem 2rem;
+  background: #111;
+}
+
+.page h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.page p {
+  font-size: 1.125rem;
+  opacity: 0.85;
+  line-height: 1.7;
+}
+
+/* Contact form */
+.contact-form {
+  max-width: 640px;
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.contact-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.contact-field label {
+  font-size: 0.95rem;
+  font-weight: 500;
+  opacity: 0.9;
+}
+
+.contact-field input,
+.contact-field textarea {
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  color: #fff;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 6px;
+  transition: border-color 0.2s;
+}
+
+.contact-field input:focus,
+.contact-field textarea:focus {
+  outline: none;
+  border-color: #666;
+}
+
+.contact-field textarea {
+  resize: vertical;
+}
+
+.contact-error {
+  font-size: 0.85rem;
+  color: #f87171;
+}
+
+.contact-success {
+  padding: 0.75rem 1rem;
+  background: #166534;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+.contact-submit {
+  align-self: flex-start;
+  padding: 0.75rem 2rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #000;
+  background: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.contact-submit:hover {
+  opacity: 0.85;
+}
+
+.contact-submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* Under construction page */
+.under-construction-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  background: #000;
+  gap: 2rem;
+  text-align: center;
+}
+
+.under-construction-logo {
+  width: auto;
+  height: auto;
+  max-width: min(300px, 80vw);
+  max-height: 120px;
+  object-fit: contain;
+}
+
+.under-construction-fallback {
+  font-size: clamp(2rem, 8vw, 3rem);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #fff;
+}
+
+.under-construction-title {
+  font-size: clamp(1.5rem, 5vw, 2.25rem);
+  font-weight: 600;
+  margin: 0;
+  color: #fff;
+}
+
+/* Homepage projects section */
+.projects-section {
+  position: relative;
+  z-index: 1;
+  background: #000;
+  padding: 4rem 2rem;
+  text-align: center;
+  color: #fff;
+}
+
+.projects-section__title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 2rem;
+}
+
+.projects-section__cards {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+}
+
+.projects-section__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  min-height: 300px;
+  overflow: hidden;
+  color: #fff;
+  text-decoration: none;
+}
+
+.projects-section__card--no-thumbnail {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.projects-section__card-image {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: 0;
+}
+
+.projects-section__card-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0, 0, 0, 0.7) 0%, transparent 60%);
+  z-index: 1;
+}
+
+.projects-section__card-tag {
+  position: relative;
+  z-index: 2;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.8;
+  padding-bottom: 0.25rem;
+}
+
+.projects-section__card-title {
+  position: relative;
+  z-index: 2;
+  font-size: 1.25rem;
+  font-weight: 600;
+  padding-bottom: 1.5rem;
+}
+
+.projects-section__link {
+  display: inline-block;
+  margin-top: 2rem;
+  color: #fff;
+  text-decoration: none;
+  font-size: 1rem;
+  opacity: 0.8;
+  transition: opacity 0.2s;
+}
+
+.projects-section__link:hover {
+  opacity: 1;
+}
+
+/* Projets page */
+.projets-page__message {
+  font-size: 1.1rem;
+  opacity: 0.6;
+  margin-top: 2rem;
+}
+
+.projets-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.5rem;
+}
+
+.projets-page__load-more {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+/* Tag filters */
+.projects-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1.5rem;
+}
+
+.projects-filters__btn {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: #fff;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  font-family: inherit;
+}
+
+.projects-filters__btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.projects-filters__btn--active {
+  background: #fff;
+  color: #000;
+}
+
+/* Project card */
+.project-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  min-height: 280px;
+  padding: 2.5rem 1.5rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  overflow: hidden;
+  transition: transform 0.3s ease;
+  color: #fff;
+  text-decoration: none;
+  font-family: inherit;
+  animation: filterCardIn 0.35s ease both;
+}
+
+.project-card:hover {
+  transform: scale(1.04);
+}
+
+/* Thumbnail image as background */
+.project-card__thumbnail {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: filter 0.4s ease;
+  z-index: 0;
+}
+
+/* Dark overlay — appears on hover */
+.project-card__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  z-index: 1;
+}
+
+.project-card:hover .project-card__thumbnail {
+  filter: blur(4px);
+}
+
+.project-card:hover .project-card__overlay {
+  opacity: 1;
+}
+
+/* Tag and title — hidden by default, appear on hover */
+.project-card__tag {
+  position: relative;
+  z-index: 2;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.project-card__title {
+  position: relative;
+  z-index: 2;
+  font-size: 1.25rem;
+  font-weight: 600;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity 0.4s ease 0.05s, transform 0.4s ease 0.05s;
+}
+
+.project-card:hover .project-card__tag,
+.project-card:hover .project-card__title {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Cards without thumbnail — show tag and title normally */
+.project-card--no-thumbnail .project-card__tag,
+.project-card--no-thumbnail .project-card__title {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.project-card--no-thumbnail .project-card__tag {
+  opacity: 0.7;
+}
+
+.project-card--no-thumbnail:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+/* Project / article detail page (shared) */
+.project-detail-wrapper,
+.article-detail-wrapper,
+.static-page-wrapper {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.project-detail,
+.article-detail {
+  margin: 0;
+}
+
+.project-detail h1,
+.article-detail h1 {
+  margin-top: 0;
+}
+
+.project-detail__back,
+.article-detail__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+  padding: 0.5rem 1rem;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 2rem;
+  color: #fff;
+  text-decoration: none;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.project-detail__back:hover,
+.article-detail__back:hover {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.25);
+}
+
+.project-detail__back-icon,
+.article-detail__back-icon {
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.project-detail__back:hover .project-detail__back-icon,
+.article-detail__back:hover .article-detail__back-icon {
+  transform: translateX(-3px);
+}
+
+.project-detail__byline,
+.article-detail__byline {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.65;
+  margin: 0 0 2rem;
+}
+
+.project-detail__byline-item:not(:last-child)::after,
+.article-detail__byline-item:not(:last-child)::after {
+  content: "·";
+  margin: 0 0.6rem;
+  opacity: 0.7;
+}
+
+.project-detail__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 2.5rem;
+  margin-top: 2rem;
+}
+
+@media (min-width: 768px) {
+  .project-detail__content:has(> aside) {
+    grid-template-columns: minmax(0, 1fr) 260px;
+    gap: 1.5rem;
+  }
+}
+
+.project-detail__credits {
+  padding-top: 2rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.project-detail__credits-heading {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  opacity: 0.55;
+  margin: 0 0 1rem;
+}
+
+.project-detail__credits-body {
+  font-size: 0.95rem;
+  line-height: 1.7;
+  opacity: 0.85;
+}
+
+.project-detail__credits-body p {
+  margin: 0 0 0.5em;
+  font-size: inherit;
+}
+
+.project-detail__credits-body p:last-child {
+  margin-bottom: 0;
+}
+
+.project-detail__credits-body a {
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.project-detail__credits-body a:hover {
+  opacity: 0.7;
+}
+
+@media (min-width: 768px) {
+  .project-detail__credits {
+    padding-top: 0;
+    padding-left: 1.5rem;
+    border-top: none;
+    border-left: 1px solid rgba(255, 255, 255, 0.1);
+  }
+
+  .project-detail__credits-body {
+    font-size: 0.8rem;
+  }
+}
+
+.project-detail__video {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  margin-top: 2rem;
+}
+
+.project-detail__video iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 0.5rem;
+}
+
+/* Network section */
+.network-section {
+  position: relative;
+  z-index: 1;
+  background: #fff;
+  padding: 4rem 2rem;
+  min-height: 50vh;
+}
+
+.network-section__title {
+  text-align: center;
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 2rem;
+  color: #111;
+}
+
+.network-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.network-filters__btn {
+  background: rgba(0, 0, 0, 0.06);
+  border: none;
+  color: #333;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  font-family: inherit;
+}
+
+.network-filters__btn:hover {
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.network-filters__btn--active {
+  background: #111;
+  color: #fff;
+}
+
+.network-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1.5rem;
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.network-card {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  background: rgba(0, 0, 0, 0.03);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  transition: background 0.2s ease;
+  animation: filterCardIn 0.35s ease both;
+}
+
+.network-card:hover {
+  background: rgba(0, 0, 0, 0.07);
+}
+
+.network-card__logo {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.network-card__name {
+  font-size: 0.85rem;
+  text-align: center;
+  color: #333;
+  opacity: 0.7;
+}
+
+/* Article detail summary */
+.article-detail__summary {
+  font-size: 1.15rem;
+  font-style: italic;
+  opacity: 0.75;
+  margin: 0 0 2rem;
+  line-height: 1.6;
+}
+
+.article-detail__illustration {
+  width: 100%;
+  max-height: 400px;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  margin: 0 0 2rem;
+}
+
+/* Shared content body styling for project and article detail pages */
+.content-overlay__body {
+  font-size: 1.1rem;
+  line-height: 1.7;
+  opacity: 0.85;
+}
+
+.content-overlay__body p {
+  margin: 0 0 0.75em;
+}
+
+.content-overlay__body p:last-child {
+  margin-bottom: 0;
+}
+
+.content-overlay__body ul,
+.content-overlay__body ol {
+  margin: 0 0 0.75em;
+  padding-left: 1.5em;
+}
+
+.content-overlay__body a {
+  color: #fff;
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+}
+
+.content-overlay__body a:hover {
+  opacity: 0.7;
+}
+
+/* Blog carousel section */
+.blog-carousel-section {
+  position: relative;
+  z-index: 1;
+  background: #111;
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.blog-carousel-section__title {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0 0 2rem;
+  color: #fff;
+}
+
+.blog-carousel-wrapper {
+  position: relative;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.blog-carousel {
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  padding: 0.5rem 0;
+}
+
+.blog-carousel::-webkit-scrollbar {
+  display: none;
+}
+
+.blog-carousel__arrow {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  color: #fff;
+  font-size: 2rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  cursor: pointer;
+  z-index: 2;
+  transition: background 0.2s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.blog-carousel__arrow:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.blog-carousel__arrow--left {
+  left: -1rem;
+}
+
+.blog-carousel__arrow--right {
+  right: -1rem;
+}
+
+.carousel-card {
+  flex: 0 0 220px;
+  scroll-snap-align: start;
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #fff;
+  font-family: inherit;
+  text-align: left;
+  padding: 0;
+  text-decoration: none;
+  transition: transform 0.3s ease;
+}
+
+.carousel-card:hover {
+  transform: scale(1.04);
+}
+
+.carousel-card__image {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 0.5rem;
+  display: block;
+}
+
+.carousel-card__placeholder {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 0.5rem;
+}
+
+.carousel-card__title {
+  display: block;
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.blog-carousel-section__link {
+  display: inline-block;
+  margin-top: 2rem;
+  color: #fff;
+  font-size: 1rem;
+  text-decoration: none;
+  opacity: 0.7;
+  transition: opacity 0.2s;
+}
+
+.blog-carousel-section__link:hover {
+  opacity: 1;
+}
+
+/* Preview banner */
+.preview-banner {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 0.6rem 1rem;
+  background: #b45309;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.preview-banner__exit {
+  color: #fff;
+  text-decoration: underline;
+  white-space: nowrap;
+}
+
+.preview-banner__exit:hover {
+  opacity: 0.8;
+}
+
+/* Blog page */
+.blog-page {
+  background: #111;
+}
+
+.blog-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 2rem;
+}
+
+.blog-filters__btn {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: #fff;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  font-family: inherit;
+}
+
+.blog-filters__btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.blog-filters__btn--active {
+  background: #fff;
+  color: #000;
+}
+
+.blog-page__message {
+  font-size: 1.1rem;
+  opacity: 0.6;
+  margin-top: 2rem;
+}
+
+.blog-masonry {
+  columns: 3 300px;
+  column-gap: 1.5rem;
+}
+
+.blog-card {
+  display: block;
+  width: 100%;
+  break-inside: avoid;
+  margin-bottom: 1.5rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: none;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  cursor: pointer;
+  color: #fff;
+  font-family: inherit;
+  text-align: left;
+  padding: 0;
+  text-decoration: none;
+  transition: transform 0.3s ease, background 0.2s ease;
+  animation: filterCardIn 0.35s ease both;
+}
+
+.blog-card:hover {
+  transform: scale(1.02);
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.blog-card__image {
+  width: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.blog-card__text {
+  padding: 1rem 1.25rem 1.25rem;
+}
+
+.blog-card__title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0 0 0.5rem;
+}
+
+.blog-card__excerpt {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  opacity: 0.7;
+  margin: 0;
+}
+
+/* Footer */
+.site-footer {
+  background: #111;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 1.5rem 2rem;
+}
+
+.site-footer__content {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.site-footer__link {
+  color: rgba(255, 255, 255, 0.7);
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: color 0.2s;
+}
+
+.site-footer__link:hover {
+  color: #fff;
+}
+
+.site-footer__copyright {
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.8rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .header {
+    padding: 1rem 1.5rem;
+  }
+
+  .header-burger {
+    display: block;
+    pointer-events: auto;
+  }
+
+  .header-nav {
+    position: fixed;
+    inset: 0;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    background: rgba(0, 0, 0, 0.95);
+    z-index: 11;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+  }
+
+  .header-nav--open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .header-nav a,
+  .header-nav .header-nav__link {
+    font-size: 1.5rem;
+  }
+
+  .page {
+    padding-top: 5rem;
+  }
+
+  .projets-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .projects-section__cards {
+    grid-template-columns: 1fr;
+  }
+
+  .projects-section__card {
+    min-height: 200px;
+  }
+
+  .projects-section {
+    padding: 3rem 1rem;
+  }
+
+  .project-card {
+    min-height: 120px;
+    padding: 1rem 1.25rem;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-end;
+  }
+
+  .project-card__overlay {
+    opacity: 1;
+    background: rgba(0, 0, 0, 0.65);
+  }
+
+  .project-card__tag,
+  .project-card__title {
+    opacity: 1;
+    transform: translateY(0);
+    text-align: left;
+  }
+
+  .project-card__tag {
+    font-size: 0.7rem;
+  }
+
+  .project-card__title {
+    font-size: 1rem;
+  }
+
+  .project-card:hover .project-card__thumbnail {
+    filter: none;
+  }
+
+  .network-section {
+    padding: 3rem 1rem;
+  }
+
+  .network-grid {
+    grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+    gap: 1rem;
+  }
+
+  /* Blog carousel mobile */
+  .blog-carousel-section {
+    padding: 3rem 1rem;
+  }
+
+  .blog-carousel__arrow {
+    display: none;
+  }
+
+  .carousel-card {
+    flex: 0 0 180px;
+  }
+
+  /* Blog page mobile */
+  .blog-masonry {
+    columns: 1;
+  }
+
+  .site-footer__content {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .project-card,
+  .blog-card,
+  .network-card {
+    animation: none;
+  }
+}

--- a/backend/static/js/site.js
+++ b/backend/static/js/site.js
@@ -1,0 +1,51 @@
+/**
+ * POC HTMX — interactions client minimales pour les pages rendues
+ * côté serveur (cf. docs/poc-htmx-a-propos.md).
+ *
+ * Reproduit deux comportements du Header.tsx Next.js :
+ *  1. Classe "header--scrolled" appliquée quand window.scrollY > 50.
+ *  2. Toggle du menu mobile (data-menu-toggle) avec verrouillage du
+ *     scroll body et fermeture sur Escape.
+ *
+ * ~30 lignes vs 110 lignes pour le composant Header.tsx (qui inclut
+ * aussi la récupération de l'auth et du logo, faits côté serveur ici).
+ */
+
+const SCROLL_THRESHOLD = 50;
+
+document.addEventListener("DOMContentLoaded", () => {
+  const header = document.querySelector("[data-scroll-aware]");
+  if (header) {
+    const onScroll = () => {
+      header.classList.toggle("header--scrolled", window.scrollY > SCROLL_THRESHOLD);
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+  }
+
+  const toggle = document.querySelector("[data-menu-toggle]");
+  const menu = document.querySelector("[data-menu]");
+  if (toggle && menu) {
+    const close = () => {
+      menu.classList.remove("header-nav--open");
+      toggle.setAttribute("aria-expanded", "false");
+      toggle.setAttribute("aria-label", "Ouvrir le menu");
+      toggle.querySelector("span").textContent = "☰";
+      document.body.style.overflow = "";
+    };
+    const open = () => {
+      menu.classList.add("header-nav--open");
+      toggle.setAttribute("aria-expanded", "true");
+      toggle.setAttribute("aria-label", "Fermer le menu");
+      toggle.querySelector("span").textContent = "✕";
+      document.body.style.overflow = "hidden";
+    };
+    toggle.addEventListener("click", () => {
+      menu.classList.contains("header-nav--open") ? close() : open();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") close();
+    });
+    menu.querySelectorAll("a").forEach((a) => a.addEventListener("click", close));
+  }
+});

--- a/backend/templates/_footer.html
+++ b/backend/templates/_footer.html
@@ -1,0 +1,9 @@
+{% now "Y" as current_year %}
+<footer class="site-footer">
+  <div class="site-footer__content">
+    <a href="/mentions-legales" class="site-footer__link">Mentions légales</a>
+    <span class="site-footer__copyright">
+      © {{ current_year }} Cultur'all. Tous droits réservés.
+    </span>
+  </div>
+</footer>

--- a/backend/templates/_header.html
+++ b/backend/templates/_header.html
@@ -1,0 +1,31 @@
+{% load wagtailimages_tags %}
+<header class="header"
+        data-scroll-aware
+        x-init>
+  <a href="/" class="header-title">
+    {% if settings.site_settings.SiteSettings.logo %}
+      {% image settings.site_settings.SiteSettings.logo width-150 alt="Cultur'all" class="header-logo" %}
+    {% else %}
+      Cultur'all
+    {% endif %}
+  </a>
+  <button class="header-burger"
+          type="button"
+          data-menu-toggle
+          aria-label="Ouvrir le menu"
+          aria-expanded="false">
+    <span aria-hidden="true">☰</span>
+  </button>
+  <nav class="header-nav" data-menu>
+    <a href="/projets">Nos Projets</a>
+    <a href="/blog">Blog</a>
+    <a href="/a-propos">À propos</a>
+    <a href="/contact">Contact</a>
+    {% if request.user.is_authenticated %}
+      <form method="post" action="{% url 'auth-logout' %}" class="header-nav__logout">
+        {% csrf_token %}
+        <button type="submit" class="header-nav__link">Déconnexion</button>
+      </form>
+    {% endif %}
+  </nav>
+</header>

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -1,0 +1,21 @@
+{% load static wagtailcore_tags wagtailimages_tags %}
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}Cultur'all{% endblock %}</title>
+  {% block meta %}
+  <meta name="description" content="Cultur'all — Site vitrine">
+  {% endblock %}
+  <link rel="stylesheet" href="{% static 'css/main.css' %}">
+  <script src="{% static 'js/site.js' %}" defer></script>
+</head>
+<body>
+  {% include "_header.html" %}
+
+  {% block content %}{% endblock %}
+
+  {% include "_footer.html" %}
+</body>
+</html>

--- a/docs/poc-htmx-a-propos.md
+++ b/docs/poc-htmx-a-propos.md
@@ -1,0 +1,184 @@
+# POC : page À propos rendue côté serveur (Django + HTMX-ready)
+
+Preuve de concept attachée à l'étude comparative
+[`stack-comparison-django-react-vs-htmx.md`](./stack-comparison-django-react-vs-htmx.md).
+Objectif : valider concrètement l'étape 3 du checklist de migration (« migrer
+les pages statiques vers un template Django/Wagtail ») en l'appliquant à
+`/a-propos/` sans casser le reste de l'application Next.js.
+
+---
+
+## TL;DR
+
+| Métrique | Avant (Next.js) | Après (Django POC) |
+|---|---|---|
+| Code spécifique à la page | `app/a-propos/page.tsx` (22 lignes TS) + `components/StaticPageContent.tsx` (62 lignes TS) | `pages/templates/pages/static_content_page.html` (12 lignes) |
+| Couche réseau | `fetch GET /api/pages/a-propos/` → JSON → `dangerouslySetInnerHTML` | Direct ORM → template, 0 hop réseau |
+| Build / runtime | Next.js + Node.js | Django seul |
+| Preview Wagtail | `wagtail-headless-preview` + endpoint `/api/preview/page/` + route `/preview` Next | Native Wagtail (gratuite, déjà installée) |
+| Tests | 0 (aucun test frontend) | 6 tests pytest, 100 % passants |
+
+Coût d'écriture du POC : ~30 minutes sur un site dont la stack n'avait
+encore aucune ligne de template Django.
+
+---
+
+## Comment tester
+
+### Lancer le backend en local
+
+```bash
+docker compose -p culturall-website \
+  -f docker-compose.base.yml \
+  -f docker-compose.dev.yml \
+  --env-file .env.dev up django postgres minio
+```
+
+Puis ouvrir :
+
+- **POC server-rendered :** http://localhost:8000/a-propos/
+- **Version Next.js actuelle (pour comparer) :** http://localhost:3000/a-propos
+
+Les deux doivent afficher le même contenu (titre + body Wagtail) avec la
+même apparence visuelle (le CSS est partagé : copié depuis
+`frontend/app/globals.css`).
+
+### Lancer les tests
+
+```bash
+cd backend && pytest pages/tests/test_html_view.py -v
+```
+
+Six tests couvrent : rendu 200, body en HTML, présence du header/footer,
+404 si dépubliée, méthode POST refusée, chargement des assets statiques.
+
+---
+
+## Ce qui a été ajouté
+
+### Nouveaux fichiers
+
+| Fichier | Rôle | LOC |
+|---|---|---|
+| `backend/templates/base.html` | Layout HTML5 (`<head>`, header, footer) | 19 |
+| `backend/templates/_header.html` | Partial header avec logo Wagtail + nav + bouton menu | 31 |
+| `backend/templates/_footer.html` | Partial footer (mentions légales + copyright) | 9 |
+| `backend/pages/templates/pages/static_content_page.html` | Template Wagtail pour `StaticContentPage` | 12 |
+| `backend/static/css/main.css` | CSS recopié 1:1 depuis `frontend/app/globals.css` | 1 176 |
+| `backend/static/js/site.js` | Scroll-aware header + toggle menu mobile | 51 |
+| `backend/pages/tests/test_html_view.py` | Tests pytest du POC | 56 |
+
+**Total nouveau code applicatif (hors CSS recopié) : ~120 lignes** —
+contre ~190 lignes TS supprimables côté frontend (`page.tsx` + `StaticPageContent.tsx`),
+plus la simplification de `Header.tsx` (passage de 110 à ~0 lignes :
+les responsabilités auth + logo + scroll deviennent du SSR + 30 lignes de JS).
+
+### Fichiers modifiés
+
+- `backend/config/settings/base.py` :
+  - `TEMPLATES["DIRS"] = [BASE_DIR / "templates"]`
+  - `STATICFILES_DIRS = [BASE_DIR / "static"]`
+  - Ajout du context processor `wagtail.contrib.settings.context_processors.settings`
+    pour exposer `SiteSettings.logo` au template.
+- `backend/config/urls.py` : route `path("a-propos/", static_page_html, …)`.
+- `backend/config/middleware.py` : ajout de `/a-propos/` aux préfixes exclus
+  de `LoginRequiredMiddleware` (cohérent avec `/api/pages/` déjà exclu).
+- `backend/pages/views.py` : ajout de la vue `static_page_html`
+  (5 lignes : `get_object_or_404` + `render`).
+
+---
+
+## Ce qui disparaît si on bascule entièrement
+
+À l'échelle du site complet (toutes pages migrées), on supprime :
+
+- `frontend/app/a-propos/`, `frontend/app/mentions-legales/`, etc.
+- `frontend/app/components/StaticPageContent.tsx`.
+- `pages/views.py::static_page_detail` et `static_page_preview_draft`.
+- Les routes `/api/pages/<slug>/` et `/api/preview/page/`.
+- L'app `wagtail_headless_preview` (la preview Wagtail native suffit).
+- La logique CORS spécifique à ces routes.
+
+---
+
+## Comparaison côte à côte du chemin de rendu
+
+### Avant (Next.js headless)
+
+```
+Browser
+  └─ GET /a-propos
+     └─ Next.js Node server
+        ├─ Render `app/a-propos/page.tsx`
+        │   └─ <StaticPageContent slug="a-propos" />
+        │       └─ async fetch GET http://django:8000/api/pages/a-propos/
+        │           └─ Django view `static_page_detail`
+        │              ├─ ORM: StaticContentPage.objects.live().get(slug=…)
+        │              ├─ expand_db_html(page.body)
+        │              └─ JsonResponse({slug, title, body})
+        │       └─ dangerouslySetInnerHTML={{ __html: page.body }}
+        └─ HTML rendu
+```
+
+5 sauts logiques, 2 process (Node + Python), 1 round-trip HTTP interne,
+1 sérialisation JSON, 1 désérialisation TS.
+
+### Après (POC Django)
+
+```
+Browser
+  └─ GET /a-propos/
+     └─ Django (Gunicorn)
+        └─ View `static_page_html`
+           ├─ ORM: StaticContentPage.objects.live().get(slug=…)
+           └─ render("pages/static_content_page.html", {"page": page})
+              └─ {{ page.body|richtext }}  (Wagtail expand_db_html appelé par le filter)
+        └─ HTML rendu
+```
+
+2 sauts logiques, 1 process, 0 round-trip HTTP, 0 JSON.
+
+---
+
+## Limites connues du POC
+
+1. **CSS dupliqué** : `backend/static/css/main.css` est une copie de
+   `frontend/app/globals.css`. Lors d'une migration réelle, le CSS serait
+   déplacé (pas dupliqué) et `frontend/` serait supprimé.
+2. **`LoginRequiredMiddleware` renvoie toujours du JSON** sur les pages
+   protégées : pour une migration complète, il faudrait le faire
+   rediriger vers `/login` quand la requête attend du HTML
+   (`request.accepts("text/html")`). Hors scope du POC.
+3. **Logo Wagtail via storage MinIO** : le `{% image %}` tag de Wagtail
+   fonctionne identiquement, mais l'URL générée pointe vers MinIO public
+   comme actuellement. Pas de régression.
+4. **Pas encore de HTMX** : la page À propos n'a aucune interactivité.
+   `django-htmx` sera ajouté quand on migrera le formulaire de contact
+   (étape 4 du checklist), où il apporte une vraie valeur (`hx-post`,
+   swap d'un partial succès/erreurs).
+5. **Pas d'image optimization automatique** : Next.js `<Image>` faisait
+   du lazy + responsive. Wagtail fournit `{% image … fill-WxH %}` et
+   `srcset` via `{% picture %}` ; à câbler sur les pages avec images
+   (blog, projets), pas nécessaire ici.
+
+---
+
+## Suite logique
+
+Si ce POC est validé, l'ordre de migration recommandé reste celui du
+checklist de l'étude comparative :
+
+1. **Mentions légales** (identique au POC, ~5 minutes).
+2. **Page d'accueil** (`HomePage` + section featured projects).
+3. **Liste blog + détail article** (introduction de `django-htmx` pour le
+   filtre par tag : `hx-get="/blog/?tag=…"` swap sur `<article-list>`).
+4. **Liste projets + détail projet**.
+5. **Formulaire de contact** (`hx-post` + partial succès/erreurs).
+6. **Auth flows** (login/logout en HTML standard, suppression du middleware
+   Next).
+7. **Suppression de `frontend/`, du service `nextjs`, de
+   `wagtail-headless-preview` et des routes `/api/preview/*`.**
+
+À l'arrivée : un seul service applicatif (Django), un seul langage côté
+serveur, la preview Wagtail native, et l'intégralité du HTML servi par
+Wagtail — ce pour quoi le CMS a été conçu.

--- a/docs/stack-comparison-django-react-vs-htmx.md
+++ b/docs/stack-comparison-django-react-vs-htmx.md
@@ -1,0 +1,140 @@
+# Étude comparative : Django + React vs Django + HTMX
+
+Document d'analyse rédigé pour évaluer si le stack actuel (Django/Wagtail headless + Next.js/React) est le plus pertinent pour `culturall-website`, ou si un retour à du rendu serveur Django + HTMX serait plus simple à maintenir.
+
+> **TL;DR** — Le site est aujourd'hui un usage typique pour lequel HTMX a été pensé : un CMS Wagtail qui sert principalement du contenu éditorial, sans interactivité client riche, sans temps réel, sans état partagé complexe. La couche Next.js fait essentiellement de la traduction JSON → HTML, ce qui est précisément le rôle natif des templates Django/Wagtail. Une migration vers Django + HTMX réduirait significativement la surface de maintenance, **à condition** d'accepter un coût de réécriture initial et de figer un certain nombre d'options d'évolution (app mobile partageant l'API, équipe spécialisée frontend, écosystème React).
+
+---
+
+## 1. Photographie du stack actuel
+
+| Dimension | État |
+|---|---|
+| Backend | Django 5.2 + Wagtail 7.4 (headless), PostgreSQL 16, MinIO (S3) |
+| API | ~13 endpoints JSON, vues Django pures (pas de DRF, pas de GraphQL) |
+| Auth | Sessions Django, pas de 2FA / OAuth / reset password |
+| Frontend | Next.js 14 (App Router, SSR), React 18, TypeScript |
+| State management | Aucun (`useState` local uniquement) |
+| UI / styles | CSS vanilla (1 176 lignes dans `globals.css`) |
+| Form library | Aucune (validation HTML native + `useState`) |
+| Data fetching | `fetch()` brut |
+| i18n | Aucune (français uniquement) |
+| Temps réel | Aucun (pas de WS, pas de SSE, pas de polling) |
+| Tâches asynchrones | Aucune (ni Celery, ni Channels) |
+| Tests frontend | **Aucun** (ni Jest, ni Vitest, ni Playwright) |
+| Tests backend | pytest, ~18 modules de tests |
+| LOC backend Python | ~3 900 |
+| LOC frontend TS/TSX | ~1 280 (dont ~600 de composants réels) |
+| LOC CSS | 1 176 |
+| Conteneurs prod | django + nextjs + postgres + minio |
+
+Sources : `backend/`, `frontend/app/`, `docker-compose.prod.yml`, `.github/workflows/`.
+
+## 2. Ce que la couche React fait réellement
+
+En parcourant `frontend/app/`, les seuls comportements qui ne sont pas de la simple mise en page de contenu Wagtail sont :
+
+- **Filtrage par tag** côté client sur la liste blog (`app/blog/page.tsx`) — recalcul d'un `Array.from(new Set(...))` à chaque sélection.
+- **Soumission du formulaire de contact** avec gestion d'état d'erreur et de soumission (`app/contact/ContactForm.tsx`, 140 lignes).
+- **Header sticky** dont le style change au scroll, plus un menu mobile avec verrouillage du scroll body et fermeture sur Escape (`app/components/Header.tsx`, 110 lignes).
+- **Middleware d'authentification** qui appelle `/api/auth/check/` à chaque requête pour rediriger vers `/login` si `require_authentication=true` (`middleware.ts`, 49 lignes).
+- **Preview Wagtail headless** via tokens signés (`app/preview/route.ts`).
+
+Tout le reste est de la consommation d'API JSON pour afficher des champs Wagtail (titre, image, rich text). Côté Wagtail ce sont des `Page` standards déjà conçues pour être rendues via templates.
+
+## 3. Coût de la complexité actuelle
+
+Le stack headless impose plusieurs coûts qui ne sont pas justifiés par les bénéfices habituels du headless (réutilisation par une app mobile, équipe frontend dédiée, interactivité riche) :
+
+1. **Deux runtimes en production** : un service Node.js standalone Next.js + Gunicorn Django. Deux process à monitorer, deux pipelines de build d'image, deux cycles de mise à jour (Next 14 → 15, Node LTS, etc.).
+2. **Une couche de sérialisation manuelle** : chaque vue Django convertit un objet Wagtail en `dict` JSON. Tout nouveau champ exige une modification synchrone backend + types TS frontend, sans aucun typage end-to-end (pas d'OpenAPI, pas de tRPC).
+3. **Un système de preview ré-implémenté** : Wagtail offre la preview en natif. La version headless oblige à passer par `wagtail-headless-preview`, des tokens signés et un endpoint `/preview` côté Next, pour reproduire ce qui marche par défaut en mode templates.
+4. **CORS, double routage, double 404** : nginx/Traefik route `/api`, `/admin`, `/static` vers Django et le reste vers Next.js. Cela complique la config locale comme prod.
+5. **Aucun test frontend** : 1 280 lignes de TS sans filet de sécurité automatisé. C'est un risque de régression à chaque montée de version.
+6. **Image optimization Next** : utile, mais Wagtail fournit déjà des renditions (`fill-600x400`, `max-200x200`) — la fonctionnalité est dupliquée.
+7. **Polyglottisme** : Python côté serveur, TypeScript côté client, deux écosystèmes de dépendances (pip + npm), deux Dockerfiles, deux logiques de migration de version.
+
+## 4. Ce qu'apporterait Django + HTMX
+
+### 4.1 Mapping concret des fonctionnalités existantes
+
+| Fonctionnalité actuelle (Next.js) | Équivalent Django + HTMX |
+|---|---|
+| Pages SSR (`/`, `/blog`, `/projets`, …) | Templates Django/Wagtail rendus par les `Page` correspondantes — déjà supporté nativement |
+| Filtrage par tag blog | `<a hx-get="/blog/?tag=foo" hx-target="#article-list" hx-push-url="true">` |
+| Formulaire de contact | `<form hx-post="/contact/" hx-target="#form-container">` qui swap avec un partial `_success.html` ou `_errors.html` |
+| Header scroll-aware + menu mobile | Alpine.js (~10 KB) ou JS vanilla < 30 lignes |
+| Auth middleware | `LoginRequiredMiddleware` Django + setting `require_authentication` déjà en place |
+| Preview Wagtail | Preview Wagtail native (gratuite) |
+| Image optimization | Renditions Wagtail + `loading="lazy"` natif HTML |
+| `next/font` | `<link rel="preload">` ou `django-compressor` |
+| Metadata API | Balises `<meta>` dans les templates de base, ou `django-meta` |
+
+### 4.2 Ce qui disparaît du dépôt
+
+- `frontend/` complet (~1 280 LOC TS + 1 176 LOC CSS, ou plutôt : le CSS reste, déplacé dans `static/`).
+- `docker/nextjs/Dockerfile` et le service `nextjs` du compose.
+- Le routage CORS et la duplication d'URL.
+- `wagtail-headless-preview` et les routes `*/preview/`.
+- Toutes les vues `views.py` qui font de la sérialisation JSON, remplacées par des templates ou supprimées si la `Page` Wagtail suffit.
+
+### 4.3 Ce qu'il faut ajouter
+
+- `django-htmx` (~5 KB) pour `request.htmx` et helpers.
+- Optionnellement `alpinejs` pour les 2-3 interactions JS résiduelles (scroll header, menu mobile).
+- Une suite de templates : `base.html`, `_header.html`, `_footer.html`, plus les templates spécifiques aux `Page` Wagtail (`blog/article_page.html`, `projects/project_page.html`, etc.).
+- Tests d'intégration côté Django (Wagtail fournit `WagtailPageTests`).
+
+## 5. Trade-offs honnêtes
+
+### Arguments **pour** la migration HTMX
+
+- **Surface de code drastiquement réduite** : on supprime un service entier, un langage, un écosystème de dépendances.
+- **Une seule source de vérité** : le modèle Wagtail rend directement son template, plus de désynchronisation API ⇄ types.
+- **Preview Wagtail native** : élimine une vraie source de bugs/complexité.
+- **i18n future plus simple** : `gettext` Django + `django.utils.translation` est mature ; ré-implémenter ça côté Next.js demanderait `next-intl` ou équivalent.
+- **Tests** : moins de surface non testée. Tester un template + une vue Wagtail est un pattern bien outillé.
+- **Moins de CVE et de mises à jour** : pas de Node, pas de Next.js majeur tous les 9 mois, pas de churn TypeScript.
+
+### Arguments **contre** la migration HTMX
+
+- **Coût de réécriture** : ~1 semaine-développeur pour un site de cette taille. Pas gratuit.
+- **Pas d'API JSON publique** : si demain une app mobile ou un partenaire doit consommer les contenus, il faudra reconstruire les endpoints (ou conserver une partie de l'API existante en parallèle).
+- **Écosystème React abandonné** : pas de retour facile en arrière, et le marché des développeurs React reste plus large que celui des développeurs Django/HTMX.
+- **Interactions très riches** : si la roadmap inclut un éditeur drag-and-drop, des graphiques interactifs, ou un dashboard temps réel, React reste mieux armé. *(D'après le README et `docs/`, ce n'est pas le cas aujourd'hui.)*
+- **Image optimization perdue** : Next.js `<Image>` fait du lazy loading + responsive automatique. Reproduire ça avec Wagtail demande un peu de travail (mais reste faisable avec `picture` + `srcset`).
+- **Préférence d'équipe** : si l'équipe est plus à l'aise en React qu'en templates Django, le bénéfice de maintenance n'est pas garanti.
+
+## 6. Recommandation
+
+Sur la base **de l'application actuelle uniquement** — pas d'une roadmap qui n'est pas documentée — le stack Django + React est **sur-dimensionné**. Les indicateurs concrets :
+
+- Le frontend sert essentiellement à afficher du contenu Wagtail.
+- Aucun test frontend n'a été écrit (ce qui suggère que l'investissement dans la couche React n'est pas pleinement rentabilisé).
+- Aucune des fonctionnalités qui justifient habituellement React (state global, optimistic UI, real-time, offline, interactions riches) n'est présente.
+- Le headless ajoute une complexité opérationnelle réelle (deux services, sérialisation manuelle, preview ré-implémentée).
+
+**Trois trajectoires possibles, du moins au plus engageant :**
+
+1. **Statu quo + tests frontend.** Garder l'architecture actuelle et ajouter une suite Vitest + Playwright. Bon choix si une app mobile ou des features interactives sont prévues à 6-12 mois.
+2. **Migration progressive vers Wagtail templates + HTMX.** Démarrer par les pages les plus statiques (`/a-propos`, `/mentions-legales`, `/contact`), puis migrer blog et projets. Conserver Next.js le temps de la transition. Permet de valider le pattern avant de s'engager.
+3. **Réécriture complète Django + HTMX + Alpine.js.** Faisable en ~1 semaine pour un site de cette taille. Maximum de gains à terme, mais demande un sprint dédié.
+
+Pour cette codebase précise, la trajectoire **(2) puis (3)** semble la plus rationnelle si l'objectif explicite est *"plus facile à maintenir"*. Si l'objectif est *"évoluer vers une plateforme plus riche"*, alors **(1)** reste défendable et il faut investir dans des tests frontend plutôt que dans un changement de stack.
+
+## 7. Si la migration est retenue : checklist de découpage
+
+1. Activer `wagtail.contrib.routable_page` ou rendu standard et créer `templates/base.html` (header, footer, slot principal).
+2. Ajouter `django-htmx` aux dépendances et le middleware associé.
+3. Migrer les pages statiques (`StaticContentPage`) vers un template `pages/static_content_page.html` — supprimer la vue `pages/views.py`.
+4. Réimplémenter le formulaire de contact en `FormView` Django + partial HTMX (`_contact_form.html`, `_contact_success.html`).
+5. Migrer la liste blog avec filtre par tag : `BlogIndexPage.serve()` retourne soit la page complète, soit le partial `_article_list.html` selon `request.htmx`.
+6. Migrer les projets de la même manière, plus la section "featured" sur la home.
+7. Réintroduire le scroll-aware header + menu mobile via Alpine.js (~30 lignes).
+8. Supprimer `wagtail-headless-preview`, les routes `*/preview/`, le middleware Next, les vues JSON.
+9. Retirer `frontend/`, le service `nextjs`, le Dockerfile correspondant, les workflows CI associés.
+10. Mettre à jour `docker-compose.*.yml`, Traefik/nginx (un seul upstream `django:8000`), le README et le guide admin.
+
+---
+
+*Document généré le 2026-05-08 sur la branche `claude/compare-django-stacks-YQVrB`.*


### PR DESCRIPTION
Factual audit of the current headless architecture (Wagtail + Next.js)
followed by a trade-off analysis and a phased migration checklist toward
server-rendered Django templates + HTMX. Recommendation aligned with the
app's actual interactivity profile (CMS-driven, low client state).

https://claude.ai/code/session_011CnWpfVs5v5n8HW6pvvYkx