### PR TITLE
Server-render /a-propos via Django + fix StaticContentPage preview

### DIFF
--- a/backend/pages/models.py
+++ b/backend/pages/models.py
@@ -1,9 +1,10 @@
 from wagtail.admin.panels import FieldPanel
 from wagtail.fields import RichTextField
 from wagtail.models import Page
+from wagtail_headless_preview.models import HeadlessPreviewMixin
 
 
-class StaticContentPage(Page):
+class StaticContentPage(HeadlessPreviewMixin, Page):
     """Page statique éditable depuis Wagtail (À propos, Mentions légales, etc.)."""
 
     body = RichTextField("Contenu", blank=True)


### PR DESCRIPTION
## Résumé

Cette branche contient le PoC de migration HTMX (server-rendering de `/a-propos/` via template Django) et l'étude comparative Django+React vs Django+HTMX, plus un correctif de la suite de tests backend qui faisait échouer le dernier déploiement.

## Changements

- **docs** : étude comparative des stacks Django+React vs Django+HTMX.
- **PoC** : rendu server-side de `/a-propos/` via template Django + preview depuis le backend.
- **fix** : `StaticContentPage` hérite désormais de `HeadlessPreviewMixin`.

## Pourquoi le fix

Le job `backend-tests` (workflow *Build & Push Images* sur `main`) échouait sur 4 tests de `TestStaticPagePreviewDraftEndpoint` :

```
AttributeError: 'StaticContentPage' object has no attribute 'create_page_preview'
AttributeError: type object 'StaticContentPage' has no attribute 'get_page_from_preview_token'
```

Ces méthodes proviennent de `HeadlessPreviewMixin` (wagtail-headless-preview). `ArticlePage` et `ProjectPage` en héritent déjà, mais `StaticContentPage` avait été créée sans, alors que `pages/views.py` et les tests l'utilisent.

## À noter pour le reviewer

- Aucune migration nécessaire : le mixin n'ajoute aucun champ DB (`makemigrations --check` → *No changes detected*).
- Suite complète : **119 passed** localement (conteneur `django`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)