### PR TITLE
Generalize server-side rendering to all StaticContentPage

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -38,11 +38,6 @@ urlpatterns = [
     # API
     path("api/contact/", contact_submit, name="contact-submit"),
 
-    # POC HTMX — rendu serveur Django/Wagtail pour la page À propos.
-    # Cf. docs/poc-htmx-a-propos.md. Ne remplace pas la route Next.js, vit
-    # à côté sur le port Django (8000) pour comparaison directe.
-    path("a-propos/", static_page_html, {"slug": "a-propos"}, name="static-page-html"),
-
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
@@ -59,9 +54,16 @@ urlpatterns = [
     path("api/preview/page/", static_page_preview_draft, name="static-page-preview-draft"),
     path("api/pages/<slug:slug>/", static_page_detail, name="static-page-detail"),
 
-    # Catch-all Wagtail (page tree) — désactivé : on est headless, Next.js
-    # gère le rendu. À activer quand on installera wagtail-headless-preview
-    # (#121) pour que la preview rédactionnelle puisse pointer ici.
+    # Rendu serveur des pages statiques (À propos, Mentions légales, …) via le
+    # template Wagtail natif. Route explicite par slug : on ne réactive PAS
+    # encore le catch-all Wagtail global (Phase 5) pour ne pas exposer les
+    # pages blog/projets/home qui n'ont pas encore de template. Placée après
+    # toutes les routes /api/ et /admin/ pour ne pas les masquer.
+    path("<slug:slug>/", static_page_html, name="static-page-html"),
+
+    # Catch-all Wagtail (page tree) — désactivé : Next.js gère encore le rendu
+    # des sections non migrées. Réactivation prévue en Phase 5 (bascule
+    # monolithe), une fois tous les templates en place.
     # path("", include(wagtail_urls)),
 ]
 

--- a/backend/pages/tests/test_html_view.py
+++ b/backend/pages/tests/test_html_view.py
@@ -1,6 +1,7 @@
-"""POC HTMX — tests pour la page À propos rendue côté serveur.
+"""Pages statiques rendues côté serveur via le template Wagtail natif.
 
-Cf. docs/poc-htmx-a-propos.md.
+Phase 1 de la migration monolithe Wagtail : généralise le rendu serveur
+(initialement limité au POC /a-propos/) à toutes les StaticContentPage.
 """
 
 import pytest
@@ -17,48 +18,57 @@ def client():
     return Client()
 
 
-class TestStaticPageHtmlView:
-    def test_renders_seeded_a_propos_page(self, client):
-        response = client.get(reverse("static-page-html"))
+def url(slug):
+    return reverse("static-page-html", kwargs={"slug": slug})
+
+
+class TestStaticPageServerRendering:
+    @pytest.mark.parametrize(
+        "slug, title",
+        [
+            ("a-propos", "À propos"),
+            ("mentions-legales", "Mentions légales"),
+        ],
+    )
+    def test_renders_seeded_pages(self, client, slug, title):
+        response = client.get(url(slug))
 
         assert response.status_code == 200
         assert response["Content-Type"].startswith("text/html")
-        assert b"<title>" in response.content
-        assert "À propos" in response.content.decode()
+        body = response.content.decode()
+        assert "<title>" in body
+        assert title in body
 
     def test_renders_body_as_html(self, client):
         page = StaticContentPage.objects.get(slug="a-propos")
         page.body = "<p>Bonjour <strong>monde</strong></p>"
         page.save()
 
-        response = client.get(reverse("static-page-html"))
-        body = response.content.decode()
-
+        body = client.get(url("a-propos")).content.decode()
         assert "<strong>monde</strong>" in body
 
     def test_includes_header_and_footer(self, client):
-        response = client.get(reverse("static-page-html"))
-        body = response.content.decode()
+        body = client.get(url("a-propos")).content.decode()
 
         assert 'class="header"' in body
         assert "Nos Projets" in body
         assert "Mentions légales" in body
         assert 'class="site-footer"' in body
 
-    def test_returns_404_when_page_unpublished(self, client):
-        page = StaticContentPage.objects.get(slug="a-propos")
-        page.unpublish()
-
-        response = client.get(reverse("static-page-html"))
-        assert response.status_code == 404
-
-    def test_only_get_allowed(self, client):
-        response = client.post(reverse("static-page-html"))
-        assert response.status_code == 405
-
     def test_loads_static_assets(self, client):
-        response = client.get(reverse("static-page-html"))
-        body = response.content.decode()
+        body = client.get(url("a-propos")).content.decode()
 
         assert "/static/css/main.css" in body
         assert "/static/js/site.js" in body
+
+    def test_returns_404_when_page_unpublished(self, client):
+        page = StaticContentPage.objects.get(slug="mentions-legales")
+        page.unpublish()
+
+        assert client.get(url("mentions-legales")).status_code == 404
+
+    def test_returns_404_for_unknown_slug(self, client):
+        assert client.get(url("slug-inexistant")).status_code == 404
+
+    def test_only_get_allowed(self, client):
+        assert client.post(url("a-propos")).status_code == 405

--- a/backend/pages/views.py
+++ b/backend/pages/views.py
@@ -1,5 +1,5 @@
 from django.http import Http404, JsonResponse
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_GET
 from wagtail.rich_text import expand_db_html
 
@@ -27,14 +27,19 @@ def static_page_detail(request, slug):
 
 @require_GET
 def static_page_html(request, slug):
-    """POC : rend la page statique côté serveur via un template Django/Wagtail.
+    """Rend une StaticContentPage côté serveur via son template Wagtail natif.
 
-    Démontre la trajectoire de migration vers Django + HTMX décrite dans
-    docs/stack-comparison-django-react-vs-htmx.md. Coexiste avec la version
-    Next.js sans la remplacer : route ouverte uniquement sur /a-propos/.
+    Sert toutes les pages statiques publiées (À propos, Mentions légales, …),
+    et plus seulement la route POC /a-propos/. Le rendu passe par
+    ``Page.serve()``, donc par la résolution de template native de Wagtail
+    (``pages/static_content_page.html``) et ``get_context()``.
+
+    La preview reste headless (HeadlessPreviewMixin) et l'API JSON coexiste
+    tant que le frontend Next.js est en place ; leur retrait est prévu en
+    Phase 5 de la migration monolithe.
     """
     page = get_object_or_404(StaticContentPage.objects.live(), slug=slug)
-    return render(request, "pages/static_content_page.html", {"page": page})
+    return page.serve(request)
 
 
 @require_GET


### PR DESCRIPTION
## Summary

Expand server-side rendering from a POC limited to `/a-propos/` to all `StaticContentPage` instances. This is Phase 1 of the Wagtail monolith migration, establishing the pattern for rendering static pages via Wagtail's native template system.

## Key Changes

- **Route generalization**: Replace hardcoded `/a-propos/` route with parameterized `<slug:slug>/` pattern to serve all published static pages
- **View simplification**: Use `page.serve(request)` instead of manual `render()` to leverage Wagtail's native template resolution and `get_context()` method
- **Test expansion**: 
  - Rename test class from `TestStaticPageHtmlView` to `TestStaticPageServerRendering` to reflect broader scope
  - Add parametrized tests covering multiple pages (`a-propos`, `mentions-legales`)
  - Add test for unknown slug 404 handling
  - Consolidate test assertions and reduce boilerplate with helper `url()` function
- **Documentation updates**: Clarify that this is Phase 1 of monolith migration, not a POC; explain coexistence with headless API and Next.js frontend

## Implementation Details

- The route is placed after all `/api/` and `/admin/` routes to avoid masking them
- The catch-all Wagtail route remains disabled (Phase 5) to prevent exposing unmigrated pages (blog, projects, home) without templates
- Headless preview and JSON API remain functional during the transition period
- Uses `@require_GET` decorator to enforce HTTP method restrictions (405 for POST)

https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF