### PR TITLE
Add server-side contact form with Django + HTMX

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -9,7 +9,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 
 from blog.views import article_detail, article_list, article_preview_draft
 from home.auth_views import auth_check, auth_login, auth_logout
-from home.views import contact_submit
+from home.views import contact_page, contact_submit
 from network.views import network_member_list
 from pages.views import static_page_detail, static_page_html, static_page_preview_draft
 from projects.views import project_detail, project_featured, project_list, project_preview_draft
@@ -53,6 +53,11 @@ urlpatterns = [
     path("api/preview/project/", project_preview_draft, name="project-preview-draft"),
     path("api/preview/page/", static_page_preview_draft, name="static-page-preview-draft"),
     path("api/pages/<slug:slug>/", static_page_detail, name="static-page-detail"),
+
+    # Page de contact rendue côté serveur (formulaire Django + HTMX). Doit
+    # précéder la route générique `<slug:slug>/` ci-dessous, sinon /contact/
+    # serait interprété comme une StaticContentPage et renverrait 404.
+    path("contact/", contact_page, name="contact"),
 
     # Rendu serveur des pages statiques (À propos, Mentions légales, …) via le
     # template Wagtail natif. Route explicite par slug : on ne réactive PAS

--- a/backend/home/forms.py
+++ b/backend/home/forms.py
@@ -1,0 +1,33 @@
+from django import forms
+
+
+class ContactForm(forms.Form):
+    """Formulaire de contact rendu côté serveur (équivalent du ContactForm.tsx).
+
+    Reprend la validation de l'endpoint JSON `contact_submit` : les quatre
+    champs sont requis (les valeurs composées uniquement d'espaces sont
+    rejetées, CharField appliquant `strip=True` par défaut).
+    """
+
+    name = forms.CharField(
+        label="Nom",
+        max_length=150,
+        error_messages={"required": "Le nom est requis."},
+    )
+    email = forms.EmailField(
+        label="Email",
+        error_messages={
+            "required": "L'email est requis.",
+            "invalid": "Veuillez saisir une adresse email valide.",
+        },
+    )
+    subject = forms.CharField(
+        label="Sujet",
+        max_length=255,
+        error_messages={"required": "Le sujet est requis."},
+    )
+    message = forms.CharField(
+        label="Message",
+        widget=forms.Textarea(attrs={"rows": 6}),
+        error_messages={"required": "Le message est requis."},
+    )

--- a/backend/home/templates/home/_contact_form.html
+++ b/backend/home/templates/home/_contact_form.html
@@ -1,0 +1,36 @@
+<form class="contact-form"
+      hx-post="{% url 'contact' %}"
+      hx-target="#form-container"
+      hx-swap="innerHTML"
+      novalidate>
+  {% csrf_token %}
+  {% if form.non_field_errors %}
+    <p class="contact-error">{{ form.non_field_errors.0 }}</p>
+  {% endif %}
+
+  <div class="contact-field">
+    <label for="{{ form.name.id_for_label }}">Nom</label>
+    {{ form.name }}
+    {% if form.name.errors %}<span class="contact-error">{{ form.name.errors.0 }}</span>{% endif %}
+  </div>
+
+  <div class="contact-field">
+    <label for="{{ form.email.id_for_label }}">Email</label>
+    {{ form.email }}
+    {% if form.email.errors %}<span class="contact-error">{{ form.email.errors.0 }}</span>{% endif %}
+  </div>
+
+  <div class="contact-field">
+    <label for="{{ form.subject.id_for_label }}">Sujet</label>
+    {{ form.subject }}
+    {% if form.subject.errors %}<span class="contact-error">{{ form.subject.errors.0 }}</span>{% endif %}
+  </div>
+
+  <div class="contact-field">
+    <label for="{{ form.message.id_for_label }}">Message</label>
+    {{ form.message }}
+    {% if form.message.errors %}<span class="contact-error">{{ form.message.errors.0 }}</span>{% endif %}
+  </div>
+
+  <button type="submit" class="contact-submit">Envoyer</button>
+</form>

--- a/backend/home/templates/home/_contact_success.html
+++ b/backend/home/templates/home/_contact_success.html
@@ -1,0 +1,1 @@
+<p class="contact-success">Votre message a bien été envoyé.</p>

--- a/backend/home/templates/home/contact_page.html
+++ b/backend/home/templates/home/contact_page.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block title %}Contact — Cultur'all{% endblock %}
+
+{% block content %}
+<main class="page">
+  <h1>Contact</h1>
+  <p>Pour toute question ou proposition, n'hésitez pas à nous contacter.</p>
+
+  <div id="form-container">
+    {% if success %}
+      {% include "home/_contact_success.html" %}
+    {% else %}
+      {% include "home/_contact_form.html" %}
+    {% endif %}
+  </div>
+</main>
+{% endblock %}

--- a/backend/home/tests/test_contact.py
+++ b/backend/home/tests/test_contact.py
@@ -68,6 +68,88 @@ class TestContactSubmitView:
         assert resp.status_code == 405
 
 
+class TestContactPageView:
+    """Page de contact rendue côté serveur (Django + HTMX)."""
+
+    url = "/contact/"
+    HTMX = {"HTTP_HX_REQUEST": "true"}
+
+    valid_payload = {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "subject": "Question",
+        "message": "Bonjour, je souhaite en savoir plus.",
+    }
+
+    def test_get_renders_form(self, client: Client):
+        resp = client.get(self.url)
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert 'class="contact-form"' in body
+        assert 'hx-post="/contact/"' in body
+        assert "csrfmiddlewaretoken" in body
+
+    def test_htmx_valid_post_creates_submission_and_returns_success(self, client: Client):
+        resp = client.post(self.url, self.valid_payload, **self.HTMX)
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "contact-success" in body
+        assert "bien été envoyé" in body
+        # Le partial succès ne contient plus le formulaire
+        assert 'class="contact-form"' not in body
+
+        assert ContactSubmission.objects.count() == 1
+        obj = ContactSubmission.objects.first()
+        assert obj.name == "Alice"
+        assert obj.email == "alice@example.com"
+        assert obj.subject == "Question"
+
+    def test_htmx_invalid_post_returns_form_with_errors(self, client: Client):
+        resp = client.post(self.url, {}, **self.HTMX)
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert 'class="contact-form"' in body
+        assert "Le nom est requis." in body
+        # L'apostrophe est échappée par Django (&#x27;) → on teste une sous-chaîne
+        assert "email est requis." in body
+        assert "Le sujet est requis." in body
+        assert "Le message est requis." in body
+        assert ContactSubmission.objects.count() == 0
+
+    def test_htmx_whitespace_only_rejected(self, client: Client):
+        payload = {"name": "  ", "email": "  ", "subject": "  ", "message": "  "}
+        resp = client.post(self.url, payload, **self.HTMX)
+
+        assert resp.status_code == 200
+        assert "contact-success" not in resp.content.decode()
+        assert ContactSubmission.objects.count() == 0
+
+    def test_non_htmx_valid_post_renders_full_page_with_success(self, client: Client):
+        resp = client.post(self.url, self.valid_payload)
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        # Page complète (header) + message de succès
+        assert 'class="header"' in body
+        assert "contact-success" in body
+        assert ContactSubmission.objects.count() == 1
+
+    def test_invalid_email_rejected(self, client: Client):
+        payload = {**self.valid_payload, "email": "pas-un-email"}
+        resp = client.post(self.url, payload, **self.HTMX)
+
+        assert resp.status_code == 200
+        assert "email valide" in resp.content.decode()
+        assert ContactSubmission.objects.count() == 0
+
+    def test_put_not_allowed(self, client: Client):
+        resp = client.put(self.url)
+        assert resp.status_code == 405
+
+
 class TestContactSubmissionModel:
     def test_str(self, db):
         obj = ContactSubmission.objects.create(

--- a/backend/home/views.py
+++ b/backend/home/views.py
@@ -1,9 +1,11 @@
 import json
 
 from django.http import JsonResponse
+from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_POST
+from django.views.decorators.http import require_http_methods, require_POST
 
+from .forms import ContactForm
 from .models import ContactSubmission
 
 
@@ -41,3 +43,28 @@ def contact_submit(request):
     )
 
     return JsonResponse({"message": "Votre message a bien été envoyé."}, status=201)
+
+
+@require_http_methods(["GET", "POST"])
+def contact_page(request):
+    """Page de contact rendue côté serveur, avec soumission HTMX.
+
+    Remplace le composant React `ContactForm.tsx`. En POST HTMX, renvoie le
+    partial à swapper dans `#form-container` (succès ou formulaire ré-affiché
+    avec ses erreurs). En l'absence de JS/HTMX, la page complète est re-rendue
+    (amélioration progressive). L'endpoint JSON `contact_submit` reste en place
+    tant que Next.js tourne ; il sera retiré en Phase 5.
+    """
+    if request.method == "POST":
+        form = ContactForm(request.POST)
+        if form.is_valid():
+            ContactSubmission.objects.create(**form.cleaned_data)
+            if request.htmx:
+                return render(request, "home/_contact_success.html")
+            return render(request, "home/contact_page.html", {"success": True})
+
+        if request.htmx:
+            return render(request, "home/_contact_form.html", {"form": form})
+        return render(request, "home/contact_page.html", {"form": form})
+
+    return render(request, "home/contact_page.html", {"form": ContactForm()})


### PR DESCRIPTION
## Summary
Implement a server-rendered contact page to replace the React `ContactForm.tsx` component. The new implementation uses Django forms with HTMX for progressive enhancement, allowing the form to work both with and without JavaScript.

## Key Changes
- **New Django form** (`ContactForm`): Validates contact submissions with the same rules as the existing JSON endpoint (required fields, email validation, whitespace trimming)
- **New view** (`contact_page`): Handles GET and POST requests, returning either full page renders or HTMX partials depending on the request type
- **New templates**:
  - `contact_page.html`: Main page template extending base layout
  - `_contact_form.html`: Reusable form partial with HTMX attributes for dynamic submission
  - `_contact_success.html`: Success message partial
- **URL routing**: Added `/contact/` route positioned before the generic slug catch-all to prevent conflicts with static pages
- **Progressive enhancement**: Non-HTMX requests receive full page renders; HTMX requests get targeted partials for efficient DOM swapping

## Implementation Details
- Form validation mirrors the existing `contact_submit` JSON endpoint to maintain consistency
- CSRF protection via Django's middleware token
- The existing JSON endpoint remains in place during the transition (Phase 5 cleanup)
- Form errors are displayed inline with user-friendly French messages
- Whitespace-only submissions are rejected (Django's `CharField` applies `strip=True` by default)

https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF