### PR TITLE
Phase 3 — Blog rendu côté serveur (listing + filtre tag HTMX + article)

### DIFF
--- a/backend/blog/models.py
+++ b/backend/blog/models.py
@@ -36,6 +36,35 @@ class BlogIndexPage(Page):
     class Meta:
         verbose_name = "Index de blog"
 
+    def _published_articles(self):
+        return (
+            ArticlePage.objects.child_of(self)
+            .live()
+            .public()
+            .prefetch_related("tags")
+            .select_related("illustration")
+            .order_by("-first_published_at")
+        )
+
+    def get_context(self, request, *args, **kwargs):
+        context = super().get_context(request, *args, **kwargs)
+        all_articles = self._published_articles()
+        current_tag = request.GET.get("tag") or None
+
+        articles = all_articles.filter(tags__name=current_tag) if current_tag else all_articles
+
+        context["articles"] = articles
+        context["current_tag"] = current_tag
+        # Tags utilisés par l'ensemble des articles publiés (indépendant du filtre).
+        context["tags"] = sorted({tag.name for article in all_articles for tag in article.tags.all()})
+        return context
+
+    def get_template(self, request, *args, **kwargs):
+        # En requête HTMX (filtre par tag), on ne renvoie que la liste à swapper.
+        if getattr(request, "htmx", False):
+            return "blog/_article_list.html"
+        return super().get_template(request, *args, **kwargs)
+
 
 class ArticlePage(HeadlessPreviewMixin, Page):
     """Article de blog publié dans l'arbre Wagtail."""

--- a/backend/blog/templates/blog/_article_list.html
+++ b/backend/blog/templates/blog/_article_list.html
@@ -1,0 +1,36 @@
+{% load wagtailcore_tags wagtailimages_tags %}
+
+{% if tags %}
+<div class="blog-filters">
+  <button type="button"
+          class="blog-filters__btn{% if not current_tag %} blog-filters__btn--active{% endif %}"
+          hx-get="{% url 'blog-index' %}"
+          hx-target="#article-list"
+          hx-push-url="true">Tous</button>
+  {% for tag in tags %}
+  <button type="button"
+          class="blog-filters__btn{% if current_tag == tag %} blog-filters__btn--active{% endif %}"
+          hx-get="{% url 'blog-index' %}?tag={{ tag|urlencode }}"
+          hx-target="#article-list"
+          hx-push-url="true">{{ tag }}</button>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if not articles %}
+  <p class="blog-page__message">Aucun article pour le moment.</p>
+{% else %}
+<div class="blog-masonry">
+  {% for article in articles %}
+  <a href="/blog/{{ article.slug }}/" class="blog-card">
+    {% if article.illustration %}
+      {% image article.illustration fill-800x500 class="blog-card__image" alt="" loading="lazy" %}
+    {% endif %}
+    <div class="blog-card__text">
+      <h3 class="blog-card__title">{{ article.title }}</h3>
+      <p class="blog-card__excerpt">{{ article.content|richtext|striptags|truncatechars:500 }}</p>
+    </div>
+  </a>
+  {% endfor %}
+</div>
+{% endif %}

--- a/backend/blog/templates/blog/article_page.html
+++ b/backend/blog/templates/blog/article_page.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags wagtailimages_tags %}
+
+{% block title %}{{ page.title }} — Cultur'all{% endblock %}
+
+{% block content %}
+<div class="page blog-page">
+  <div class="article-detail-wrapper">
+    <a href="/blog/" class="article-detail__back">
+      <span class="article-detail__back-icon" aria-hidden="true">←</span>
+      <span>Blog</span>
+    </a>
+
+    <article class="article-detail">
+      <h1>{{ page.title }}</h1>
+
+      {% if page.tags.all %}
+      <div class="article-detail__byline">
+        {% for tag in page.tags.all %}
+          <span class="article-detail__byline-item">{{ tag.name }}</span>
+        {% endfor %}
+      </div>
+      {% endif %}
+
+      {% if page.illustration %}
+        {% image page.illustration fill-800x500 class="article-detail__illustration" alt="" loading="lazy" %}
+      {% endif %}
+
+      {% if page.summary %}
+        <p class="article-detail__summary">{{ page.summary }}</p>
+      {% endif %}
+
+      <div class="content-overlay__body">{{ page.content|richtext }}</div>
+    </article>
+  </div>
+</div>
+{% endblock %}

--- a/backend/blog/templates/blog/blog_index_page.html
+++ b/backend/blog/templates/blog/blog_index_page.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags %}
+
+{% block title %}Blog — Cultur'all{% endblock %}
+
+{% block content %}
+<div class="page blog-page">
+  <h1>Blog</h1>
+  {% if page.intro %}<div>{{ page.intro|richtext }}</div>{% endif %}
+
+  <div id="article-list">
+    {% include "blog/_article_list.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/backend/blog/tests/test_html.py
+++ b/backend/blog/tests/test_html.py
@@ -1,0 +1,96 @@
+"""Blog rendu côté serveur (Phase 3) : listing + filtre par tag HTMX + article."""
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+HTMX = {"HTTP_HX_REQUEST": "true"}
+
+
+class TestBlogIndex:
+    def test_lists_published_articles(self, client, make_article):
+        make_article(title="Premier article")
+        make_article(title="Second article")
+
+        resp = client.get("/blog/")
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Premier article" in body
+        assert "Second article" in body
+        assert "blog-masonry" in body
+        # Page complète → layout de base présent
+        assert 'class="header"' in body
+
+    def test_excludes_drafts(self, client, make_article):
+        article = make_article(title="Brouillon")
+        article.unpublish()
+
+        resp = client.get("/blog/")
+        assert "Brouillon" not in resp.content.decode()
+
+    def test_empty_state(self, client, blog_index):
+        resp = client.get("/blog/")
+        assert resp.status_code == 200
+        assert "Aucun article" in resp.content.decode()
+
+    def test_tag_filter_excludes_other_tags(self, client, make_article):
+        tagged = make_article(title="Avec tag")
+        tagged.tags.add("Actualité")
+        tagged.save()  # modelcluster : les tags ne sont persistés qu'au save()
+        make_article(title="Sans tag")
+
+        body = client.get("/blog/?tag=Actualité").content.decode()
+        assert "Avec tag" in body
+        assert "Sans tag" not in body
+
+    def test_filter_chips_list_all_tags(self, client, make_article):
+        article = make_article(title="A")
+        article.tags.add("Actualité", "Culture")
+        article.save()
+
+        body = client.get("/blog/").content.decode()
+        assert "blog-filters" in body
+        assert "Actualité" in body
+        assert "Culture" in body
+
+    def test_htmx_returns_partial_without_layout(self, client, make_article):
+        make_article(title="Article HTMX")
+
+        resp = client.get("/blog/", **HTMX)
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Article HTMX" in body
+        # Partial seul : pas de <header> du layout de base
+        assert 'class="header"' not in body
+        assert "blog-masonry" in body
+
+
+class TestArticleDetail:
+    def test_renders_published_article(self, client, make_article):
+        article = make_article(title="Mon Article", content="<p>Contenu riche ici</p>")
+        article.tags.add("Actualité")
+        article.save()
+
+        resp = client.get(f"/blog/{article.slug}/")
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Mon Article" in body
+        assert "Contenu riche ici" in body
+        assert "Actualité" in body
+        assert "article-detail" in body
+        assert 'href="/blog/"' in body  # lien retour
+
+    def test_404_for_unknown_slug(self, client, blog_index):
+        assert client.get("/blog/inexistant/").status_code == 404
+
+    def test_404_for_unpublished(self, client, make_article):
+        article = make_article(title="Caché")
+        article.unpublish()
+        assert client.get(f"/blog/{article.slug}/").status_code == 404
+
+    def test_only_get_allowed(self, client, make_article):
+        article = make_article(title="X")
+        assert client.post(f"/blog/{article.slug}/").status_code == 405

--- a/backend/blog/views.py
+++ b/backend/blog/views.py
@@ -1,8 +1,9 @@
 from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_GET
 from wagtail.rich_text import expand_db_html
 
-from .models import ArticlePage
+from .models import ArticlePage, BlogIndexPage
 
 
 def _serialize_article(request, article):
@@ -89,3 +90,25 @@ def article_preview_draft(request):
         raise Http404("Token introuvable ou expiré")
 
     return JsonResponse(_serialize_article(request, page))
+
+
+# ─── Rendu serveur (Phase 3) ───────────────────────────────────
+# Routes explicites tant que le catch-all Wagtail global est désactivé
+# (réactivation Phase 5). Le rendu passe par Page.serve() : BlogIndexPage
+# gère le filtre par tag + le partial HTMX via get_context/get_template.
+
+
+@require_GET
+def blog_index(request):
+    """Liste des articles (page complète, ou partial HTMX si filtre par tag)."""
+    page = BlogIndexPage.objects.live().first()
+    if page is None:
+        raise Http404("Blog introuvable")
+    return page.serve(request)
+
+
+@require_GET
+def article_page(request, slug):
+    """Détail d'un article publié, rendu via son template Wagtail natif."""
+    article = get_object_or_404(ArticlePage.objects.live().public(), slug=slug)
+    return article.serve(request)

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -7,7 +7,13 @@ from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 
-from blog.views import article_detail, article_list, article_preview_draft
+from blog.views import (
+    article_detail,
+    article_list,
+    article_page,
+    article_preview_draft,
+    blog_index,
+)
 from home.auth_views import auth_check, auth_login, auth_logout
 from home.views import contact_page, contact_submit
 from network.views import network_member_list
@@ -58,6 +64,12 @@ urlpatterns = [
     # précéder la route générique `<slug:slug>/` ci-dessous, sinon /contact/
     # serait interprété comme une StaticContentPage et renverrait 404.
     path("contact/", contact_page, name="contact"),
+
+    # Blog rendu côté serveur (Phase 3). Routes explicites placées avant la
+    # route générique `<slug:slug>/` (sinon /blog/ serait pris pour une page
+    # statique). /blog/ = listing (+ filtre tag HTMX), /blog/<slug>/ = article.
+    path("blog/", blog_index, name="blog-index"),
+    path("blog/<slug:slug>/", article_page, name="article-page"),
 
     # Rendu serveur des pages statiques (À propos, Mentions légales, …) via le
     # template Wagtail natif. Route explicite par slug : on ne réactive PAS


### PR DESCRIPTION
## Résumé

Phase 3 de la migration monolithe Wagtail (#156, épic #152) : rend le blog côté serveur (listing + filtre par tag en HTMX + page article), via le template natif Wagtail. Next.js et l'API JSON restent en place pendant la transition.

## Changements

- **`BlogIndexPage`** : `get_context` (articles publiés, filtre `?tag`, liste des tags) + `get_template` qui renvoie le partial `_article_list.html` en requête HTMX, sinon la page complète.
- **Templates** :
  - `blog_index_page.html` (page + conteneur `#article-list`)
  - `_article_list.html` : barre de filtres (boutons `hx-get` / `hx-target="#article-list"` / `hx-push-url`) + cartes ; filtres et liste dans le même partial → le tag actif se met à jour au swap
  - `article_page.html` : titre, tags, illustration en rendition `fill-800x500` + `loading="lazy"`, contenu rich text, lien retour
  - Réutilise les classes CSS existantes (`blog-masonry`, `blog-card`, `blog-filters`, `article-detail`…)
- **Vues serveur** `blog_index` (`/blog/`) et `article_page` (`/blog/<slug>/`), via `Page.serve()`. Routes placées **avant** la route générique `<slug:slug>/`. Le catch-all Wagtail global reste désactivé (Phase 5).
- API JSON blog et **preview headless conservées** (retrait prévu en Phase 5).

## Tests

10 nouveaux tests (listing, drafts exclus, état vide, filtre par tag, chips de tags, partial HTMX sans layout, détail article, 404 slug inconnu/dépublié, méthode non autorisée). Suite backend : **141 passants**.

https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF)_