### PR TITLE
Phase 4 — Projets & Home rendus côté serveur

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.http import HttpResponse
 from django.urls import include, path
 from wagtail import urls as wagtail_urls
 from wagtail.admin import urls as wagtailadmin_urls
@@ -15,26 +14,23 @@ from blog.views import (
     blog_index,
 )
 from home.auth_views import auth_check, auth_login, auth_logout
-from home.views import contact_page, contact_submit
+from home.views import contact_page, contact_submit, home_page
 from network.views import network_member_list
 from pages.views import static_page_detail, static_page_html, static_page_preview_draft
-from projects.views import project_detail, project_featured, project_list, project_preview_draft
-
-
-def hello(request):
-    return HttpResponse(
-        "<h1>Hello, World!</h1>"
-        "<p>Backend Django + Wagtail prêt. "
-        "<a href='/admin/'>Wagtail admin</a> — "
-        "<a href='/django-admin/'>Django admin</a></p>"
-    )
+from projects.views import (
+    project_detail,
+    project_featured,
+    project_list,
+    project_page,
+    project_preview_draft,
+    projects_index,
+)
 
 
 urlpatterns = [
-    # HelloWorld root view — le backend est headless, le rendu HTML est fait
-    # par Next.js. Le catch-all Wagtail (plus bas) reste désactivé tant qu'on
-    # n'a pas câblé wagtail-headless-preview (#121).
-    path("", hello),
+    # Page d'accueil rendue côté serveur (Phase 4) : vidéo landing + projets
+    # à la une + section réseau.
+    path("", home_page, name="home"),
 
     # API — Auth
     path("api/auth/check/", auth_check, name="auth-check"),
@@ -70,6 +66,11 @@ urlpatterns = [
     # statique). /blog/ = listing (+ filtre tag HTMX), /blog/<slug>/ = article.
     path("blog/", blog_index, name="blog-index"),
     path("blog/<slug:slug>/", article_page, name="article-page"),
+
+    # Projets rendus côté serveur (Phase 4). Mêmes contraintes d'ordre que le
+    # blog : avant la route générique <slug:slug>/.
+    path("projets/", projects_index, name="projects-index"),
+    path("projets/<slug:slug>/", project_page, name="project-page"),
 
     # Rendu serveur des pages statiques (À propos, Mentions légales, …) via le
     # template Wagtail natif. Route explicite par slug : on ne réactive PAS

--- a/backend/home/models.py
+++ b/backend/home/models.py
@@ -22,7 +22,26 @@ from wagtail.snippets.views.snippets import SnippetViewSet
 
 
 class HomePage(Page):
-    pass
+    def get_context(self, request, *args, **kwargs):
+        # Imports locaux pour éviter tout souci d'ordre de chargement des apps.
+        from network.models import NetworkMember
+        from projects.models import MAX_FEATURED_PROJECTS, ProjectPage
+
+        context = super().get_context(request, *args, **kwargs)
+
+        context["featured_projects"] = (
+            ProjectPage.objects.live()
+            .public()
+            .filter(featured=True)
+            .select_related("thumbnail")
+            .prefetch_related("tags")
+            .order_by("-first_published_at")[:MAX_FEATURED_PROJECTS]
+        )
+
+        members = list(NetworkMember.objects.select_related("logo").all())
+        context["network_members"] = members
+        context["network_types"] = sorted({m.member_type for m in members})
+        return context
 
 
 class ReadOnlyPermissionPolicy(ModelPermissionPolicy):

--- a/backend/home/templates/home/home_page.html
+++ b/backend/home/templates/home/home_page.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% load wagtailimages_tags %}
+
+{% block title %}Cultur'all{% endblock %}
+
+{% block content %}
+<div class="landing">
+  <div class="landing-video">
+    <iframe
+      src="https://www.youtube.com/embed/0L8953RVKGU?autoplay=1&mute=1&loop=1&playlist=0L8953RVKGU&controls=0&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3&disablekb=1&fs=0&cc_load_policy=0"
+      allow="autoplay; encrypted-media"
+      title="Vidéo de fond Cultur'all"></iframe>
+  </div>
+</div>
+
+{% if featured_projects %}
+<section class="projects-section">
+  <h2 class="projects-section__title">Les projets à la une</h2>
+  <div class="projects-section__cards">
+    {% for project in featured_projects %}
+    <a href="/projets/{{ project.slug }}/" class="projects-section__card{% if not project.thumbnail %} projects-section__card--no-thumbnail{% endif %}">
+      {% if project.thumbnail %}
+        {% image project.thumbnail fill-600x400 class="projects-section__card-image" alt="" loading="lazy" %}
+      {% endif %}
+      <div class="projects-section__card-overlay"></div>
+      <span class="projects-section__card-tag">{% with project.tags.all|first as first_tag %}{% if first_tag %}{{ first_tag.name }}{% endif %}{% endwith %}</span>
+      <span class="projects-section__card-title">{{ project.title }}</span>
+    </a>
+    {% endfor %}
+  </div>
+  <a href="/projets/" class="projects-section__link">Voir tous les projets →</a>
+</section>
+{% endif %}
+
+{% if network_members %}
+<section class="network-section" x-data="{ activeType: null }">
+  <h2 class="network-section__title">Notre Réseau</h2>
+
+  {% if network_types|length > 1 %}
+  <div class="network-filters">
+    <button type="button"
+            class="network-filters__btn"
+            :class="{ 'network-filters__btn--active': activeType === null }"
+            @click="activeType = null">Tous</button>
+    {% for type in network_types %}
+    <button type="button"
+            class="network-filters__btn"
+            :class="{ 'network-filters__btn--active': activeType === '{{ type|escapejs }}' }"
+            @click="activeType = '{{ type|escapejs }}'">{{ type }}</button>
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  <div class="network-grid">
+    {% for member in network_members %}
+    <div class="network-card"
+         title="{{ member.name }}"
+         x-show="activeType === null || activeType === '{{ member.member_type|escapejs }}'">
+      {% if member.logo %}
+        {% image member.logo max-200x200 as logo_rendition %}
+        <img src="{{ logo_rendition.url }}" alt="{{ member.name }}" class="network-card__logo" loading="lazy">
+      {% else %}
+        <span class="network-card__name">{{ member.name }}</span>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+</section>
+{% endif %}
+{% endblock %}

--- a/backend/home/templates/home/home_page.html
+++ b/backend/home/templates/home/home_page.html
@@ -9,6 +9,7 @@
     <iframe
       src="https://www.youtube.com/embed/0L8953RVKGU?autoplay=1&mute=1&loop=1&playlist=0L8953RVKGU&controls=0&rel=0&modestbranding=1&playsinline=1&iv_load_policy=3&disablekb=1&fs=0&cc_load_policy=0"
       allow="autoplay; encrypted-media"
+      referrerpolicy="strict-origin-when-cross-origin"
       title="Vidéo de fond Cultur'all"></iframe>
   </div>
 </div>

--- a/backend/home/tests/conftest.py
+++ b/backend/home/tests/conftest.py
@@ -1,0 +1,42 @@
+import pytest
+from django.utils import timezone
+from wagtail.models import Page, Site
+
+from home.models import HomePage
+from projects.models import ProjectPage, ProjectsIndexPage
+
+
+@pytest.fixture
+def home_tree(db):
+    """Garantit l'arbre root → HomePage → ProjectsIndexPage et retourne l'index projets."""
+    home = HomePage.objects.first()
+    if home is None:
+        root = Page.objects.filter(depth=1).first() or Page.add_root(title="Root")
+        home = HomePage(title="Home", slug="home")
+        root.add_child(instance=home)
+        site = Site.objects.filter(is_default_site=True).first()
+        if site is not None:
+            site.root_page = home
+            site.save()
+
+    index = ProjectsIndexPage.objects.first()
+    if index is None:
+        index = ProjectsIndexPage(title="Projets", slug="projets")
+        home.add_child(instance=index)
+    return index
+
+
+@pytest.fixture
+def make_project(home_tree):
+    """Crée un ProjectPage publié sous la ProjectsIndexPage. Slug auto-incrémenté."""
+    counter = {"n": 0}
+
+    def _make(title="Projet", youtube_url="https://youtube.com/watch?v=test", **kwargs):
+        counter["n"] += 1
+        kwargs.setdefault("slug", f"projet-{counter['n']}")
+        kwargs.setdefault("first_published_at", timezone.now())
+        project = ProjectPage(title=title, youtube_url=youtube_url, **kwargs)
+        home_tree.add_child(instance=project)
+        return project
+
+    return _make

--- a/backend/home/tests/test_home_html.py
+++ b/backend/home/tests/test_home_html.py
@@ -1,0 +1,46 @@
+"""Page d'accueil rendue côté serveur (Phase 4) : landing + projets à la une + réseau."""
+
+import pytest
+
+from network.models import NetworkMember
+
+pytestmark = pytest.mark.django_db
+
+
+class TestHomePage:
+    def test_renders_landing_and_sections(self, client, make_project):
+        make_project(title="Projet à la une", featured=True)
+        NetworkMember.objects.create(name="Partenaire A", member_type="Partenaire")
+
+        resp = client.get("/")
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "landing-video" in body
+        assert "projects-section" in body
+        assert "Projet à la une" in body
+        assert "network-section" in body
+        assert "Partenaire A" in body
+
+    def test_only_featured_projects_shown(self, client, make_project):
+        make_project(title="En avant", featured=True)
+        make_project(title="Pas en avant", featured=False)
+
+        body = client.get("/").content.decode()
+        assert "En avant" in body
+        assert "Pas en avant" not in body
+
+    def test_network_type_filter_chips(self, client, make_project):
+        make_project(title="P")  # garantit l'existence de la HomePage
+        NetworkMember.objects.create(name="A", member_type="Partenaire")
+        NetworkMember.objects.create(name="B", member_type="Financeur")
+
+        body = client.get("/").content.decode()
+        assert "network-filters" in body
+        assert "Partenaire" in body
+        assert "Financeur" in body
+
+    def test_no_network_section_when_empty(self, client, make_project):
+        make_project(title="P")
+        body = client.get("/").content.decode()
+        assert "network-section" not in body

--- a/backend/home/views.py
+++ b/backend/home/views.py
@@ -1,12 +1,21 @@
 import json
 
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
 from django.shortcuts import render
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods, require_POST
+from django.views.decorators.http import require_GET, require_http_methods, require_POST
 
 from .forms import ContactForm
-from .models import ContactSubmission
+from .models import ContactSubmission, HomePage
+
+
+@require_GET
+def home_page(request):
+    """Page d'accueil rendue côté serveur (vidéo landing + projets à la une + réseau)."""
+    page = HomePage.objects.live().first()
+    if page is None:
+        raise Http404("Page d'accueil introuvable")
+    return page.serve(request)
 
 
 @csrf_exempt

--- a/backend/projects/models.py
+++ b/backend/projects/models.py
@@ -1,3 +1,5 @@
+import re
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from modelcluster.contrib.taggit import ClusterTaggableManager
@@ -10,6 +12,11 @@ from wagtail.models import Page
 from wagtail_headless_preview.models import HeadlessPreviewMixin
 
 MAX_FEATURED_PROJECTS = 3
+
+# Extrait l'ID d'une vidéo YouTube depuis les formats watch / youtu.be / embed / shorts.
+_YOUTUBE_ID_RE = re.compile(
+    r"(?:youtu\.be/|youtube\.com/(?:watch\?.*v=|embed/|shorts/))([a-zA-Z0-9_-]{11})"
+)
 
 
 class ProjectPageTag(TaggedItemBase):
@@ -33,6 +40,34 @@ class ProjectsIndexPage(Page):
 
     class Meta:
         verbose_name = "Index des projets"
+
+    def _published_projects(self):
+        return (
+            ProjectPage.objects.child_of(self)
+            .live()
+            .public()
+            .prefetch_related("tags")
+            .select_related("thumbnail")
+            .order_by("-first_published_at")
+        )
+
+    def get_context(self, request, *args, **kwargs):
+        context = super().get_context(request, *args, **kwargs)
+        all_projects = self._published_projects()
+        current_tag = request.GET.get("tag") or None
+
+        projects = all_projects.filter(tags__name=current_tag) if current_tag else all_projects
+
+        context["projects"] = projects
+        context["current_tag"] = current_tag
+        context["tags"] = sorted({tag.name for project in all_projects for tag in project.tags.all()})
+        return context
+
+    def get_template(self, request, *args, **kwargs):
+        # En requête HTMX (filtre par tag), on ne renvoie que la grille à swapper.
+        if getattr(request, "htmx", False):
+            return "projects/_project_list.html"
+        return super().get_template(request, *args, **kwargs)
 
 
 class ProjectPage(HeadlessPreviewMixin, Page):
@@ -90,3 +125,11 @@ class ProjectPage(HeadlessPreviewMixin, Page):
     def save(self, *args, **kwargs):
         self.clean()
         super().save(*args, **kwargs)
+
+    @property
+    def youtube_id(self):
+        """ID de la vidéo YouTube extrait de youtube_url (None si introuvable)."""
+        if not self.youtube_url:
+            return None
+        match = _YOUTUBE_ID_RE.search(self.youtube_url)
+        return match.group(1) if match else None

--- a/backend/projects/templates/projects/_project_list.html
+++ b/backend/projects/templates/projects/_project_list.html
@@ -1,0 +1,35 @@
+{% load wagtailimages_tags %}
+
+{% if tags %}
+<div class="projects-filters">
+  <button type="button"
+          class="projects-filters__btn{% if not current_tag %} projects-filters__btn--active{% endif %}"
+          hx-get="{% url 'projects-index' %}"
+          hx-target="#project-list"
+          hx-push-url="true">Tous</button>
+  {% for tag in tags %}
+  <button type="button"
+          class="projects-filters__btn{% if current_tag == tag %} projects-filters__btn--active{% endif %}"
+          hx-get="{% url 'projects-index' %}?tag={{ tag|urlencode }}"
+          hx-target="#project-list"
+          hx-push-url="true">{{ tag }}</button>
+  {% endfor %}
+</div>
+{% endif %}
+
+{% if not projects %}
+  <p class="projets-page__message">Aucun projet pour le moment.</p>
+{% else %}
+<div class="projets-grid">
+  {% for project in projects %}
+  <a href="/projets/{{ project.slug }}/" class="project-card{% if not project.thumbnail %} project-card--no-thumbnail{% endif %}">
+    {% if project.thumbnail %}
+      {% image project.thumbnail fill-600x400 class="project-card__thumbnail" alt="" loading="lazy" %}
+      <div class="project-card__overlay"></div>
+    {% endif %}
+    <span class="project-card__tag">{% with project.tags.all|first as first_tag %}{% if first_tag %}{{ first_tag.name }}{% endif %}{% endwith %}</span>
+    <span class="project-card__title">{{ project.title }}</span>
+  </a>
+  {% endfor %}
+</div>
+{% endif %}

--- a/backend/projects/templates/projects/project_page.html
+++ b/backend/projects/templates/projects/project_page.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+{% load wagtailcore_tags wagtailimages_tags %}
+
+{% block title %}{{ page.title }} — Cultur'all{% endblock %}
+
+{% block content %}
+<div class="page projets-page">
+  <div class="project-detail-wrapper">
+    <a href="/projets/" class="project-detail__back">
+      <span class="project-detail__back-icon" aria-hidden="true">←</span>
+      <span>Projets</span>
+    </a>
+
+    <article class="project-detail">
+      <h1>{{ page.title }}</h1>
+
+      {% if page.tags.all or page.year or page.video_duration %}
+      <div class="project-detail__byline">
+        {% for tag in page.tags.all %}
+          <span class="project-detail__byline-item">{{ tag.name }}</span>
+        {% endfor %}
+        {% if page.year %}<span class="project-detail__byline-item">{{ page.year }}</span>{% endif %}
+        {% if page.video_duration %}<span class="project-detail__byline-item">{{ page.video_duration }}</span>{% endif %}
+      </div>
+      {% endif %}
+
+      {% if page.youtube_id %}
+      <div class="project-detail__video">
+        <iframe src="https://www.youtube.com/embed/{{ page.youtube_id }}"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+                sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+                loading="lazy"
+                allowfullscreen
+                title="{{ page.title }}"></iframe>
+      </div>
+      {% endif %}
+
+      <div class="project-detail__content">
+        <div class="content-overlay__body">{{ page.description|richtext }}</div>
+        {% if page.credits %}
+        <aside class="project-detail__credits">
+          <h2 class="project-detail__credits-heading">Crédits</h2>
+          <div class="project-detail__credits-body">{{ page.credits|richtext }}</div>
+        </aside>
+        {% endif %}
+      </div>
+    </article>
+  </div>
+</div>
+{% endblock %}

--- a/backend/projects/templates/projects/project_page.html
+++ b/backend/projects/templates/projects/project_page.html
@@ -29,6 +29,7 @@
         <iframe src="https://www.youtube.com/embed/{{ page.youtube_id }}"
                 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
                 sandbox="allow-scripts allow-same-origin allow-presentation allow-popups"
+                referrerpolicy="strict-origin-when-cross-origin"
                 loading="lazy"
                 allowfullscreen
                 title="{{ page.title }}"></iframe>

--- a/backend/projects/templates/projects/projects_index_page.html
+++ b/backend/projects/templates/projects/projects_index_page.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block title %}Nos Projets — Cultur'all{% endblock %}
+
+{% block content %}
+<div class="page projets-page">
+  <h1>Nos Projets</h1>
+
+  <div id="project-list">
+    {% include "projects/_project_list.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/backend/projects/tests/test_html.py
+++ b/backend/projects/tests/test_html.py
@@ -1,0 +1,84 @@
+"""Projets rendus côté serveur (Phase 4) : listing + filtre tag HTMX + détail."""
+
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+HTMX = {"HTTP_HX_REQUEST": "true"}
+
+
+class TestProjectsIndex:
+    def test_lists_published_projects(self, client, make_project):
+        make_project(title="Projet Un")
+        make_project(title="Projet Deux")
+
+        resp = client.get("/projets/")
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Projet Un" in body
+        assert "Projet Deux" in body
+        assert "projets-grid" in body
+        assert 'class="header"' in body
+
+    def test_excludes_drafts(self, client, make_project):
+        project = make_project(title="Brouillon")
+        project.unpublish()
+        assert "Brouillon" not in client.get("/projets/").content.decode()
+
+    def test_empty_state(self, client, projects_index):
+        resp = client.get("/projets/")
+        assert resp.status_code == 200
+        assert "Aucun projet" in resp.content.decode()
+
+    def test_tag_filter_excludes_other_tags(self, client, make_project):
+        tagged = make_project(title="Avec tag")
+        tagged.tags.add("Danse")
+        tagged.save()
+        make_project(title="Sans tag")
+
+        body = client.get("/projets/?tag=Danse").content.decode()
+        assert "Avec tag" in body
+        assert "Sans tag" not in body
+
+    def test_htmx_returns_partial_without_layout(self, client, make_project):
+        make_project(title="Projet HTMX")
+
+        resp = client.get("/projets/", **HTMX)
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Projet HTMX" in body
+        assert 'class="header"' not in body
+        assert "projets-grid" in body
+
+
+class TestProjectDetail:
+    def test_renders_with_video(self, client, make_project):
+        project = make_project(
+            title="Mon Projet",
+            description="<p>Une description riche</p>",
+            youtube_url="https://www.youtube.com/watch?v=abcdefghijk",
+        )
+
+        resp = client.get(f"/projets/{project.slug}/")
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "Mon Projet" in body
+        assert "Une description riche" in body
+        assert "youtube.com/embed/abcdefghijk" in body
+        assert "project-detail" in body
+        assert 'href="/projets/"' in body
+
+    def test_404_for_unknown_slug(self, client, projects_index):
+        assert client.get("/projets/inexistant/").status_code == 404
+
+    def test_404_for_unpublished(self, client, make_project):
+        project = make_project(title="Caché")
+        project.unpublish()
+        assert client.get(f"/projets/{project.slug}/").status_code == 404
+
+    def test_only_get_allowed(self, client, make_project):
+        project = make_project(title="X")
+        assert client.post(f"/projets/{project.slug}/").status_code == 405

--- a/backend/projects/views.py
+++ b/backend/projects/views.py
@@ -1,8 +1,9 @@
 from django.http import Http404, JsonResponse
+from django.shortcuts import get_object_or_404
 from django.views.decorators.http import require_GET
 from wagtail.rich_text import expand_db_html
 
-from .models import ProjectPage
+from .models import ProjectPage, ProjectsIndexPage
 
 
 def _base_queryset():
@@ -87,3 +88,24 @@ def project_preview_draft(request):
         raise Http404("Token introuvable ou expiré")
 
     return JsonResponse(_serialize_project(request, page))
+
+
+# ─── Rendu serveur (Phase 4) ───────────────────────────────────
+# Routes explicites tant que le catch-all Wagtail global est désactivé
+# (réactivation Phase 5). Rendu via Page.serve().
+
+
+@require_GET
+def projects_index(request):
+    """Liste des projets (page complète, ou partial HTMX si filtre par tag)."""
+    page = ProjectsIndexPage.objects.live().first()
+    if page is None:
+        raise Http404("Page projets introuvable")
+    return page.serve(request)
+
+
+@require_GET
+def project_page(request, slug):
+    """Détail d'un projet publié, rendu via son template Wagtail natif."""
+    project = get_object_or_404(ProjectPage.objects.live().public(), slug=slug)
+    return project.serve(request)


### PR DESCRIPTION
## Résumé

Phase 4 de la migration monolithe Wagtail (#157, épic #152) : rend les **projets** (listing + filtre tag HTMX + détail avec embed YouTube) et la **page d'accueil** (vidéo landing + projets à la une + section réseau) côté serveur. Next.js et l'API JSON restent en place pendant la transition.

## Changements

**Projets**
- `ProjectsIndexPage` : `get_context` (projets publiés, filtre `?tag`, tags) + `get_template` (partial `_project_list` en HTMX).
- Templates `projects_index_page.html`, `_project_list.html` (filtres `hx-get` + grille), `project_page.html` (byline, embed YouTube, description + crédits).
- Propriété `ProjectPage.youtube_id` (extraction regex) pour l'URL d'embed.
- Vues `projects_index` (`/projets/`) et `project_page` (`/projets/<slug>/`), avant la route générique `<slug:slug>/`.

**Home**
- `HomePage.get_context` : projets à la une (max 3) + membres du réseau (snippets) + types.
- `home_page.html` : vidéo landing + section projets à la une + section réseau avec **filtre par type en Alpine** (show/hide côté client, contenu déjà rendu serveur).
- Vue `home_page` servie sur `/` (remplace le placeholder `hello`).

**Divers**
- Réutilise les classes CSS existantes.
- API JSON projets/réseau + preview headless **conservées** (retrait Phase 5).
- **Pas de carrousel blog** sur la home : il n'existait pas dans le frontend Next.js actuel.
- Fix embeds YouTube : `referrerpolicy="strict-origin-when-cross-origin"` (le `Referrer-Policy: same-origin` de Django cassait le lecteur → erreur 153).

## Tests

13 nouveaux tests (listing projets, filtre tag, partial HTMX, détail + embed, 404 ; home landing/sections, featured only, filtres réseau, réseau vide). Suite backend : **154 passants**.

https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF)_