### PR TITLE
Phase 5a — Réactiver le catch-all Wagtail

### DIFF
--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -73,16 +73,16 @@ urlpatterns = [
     path("projets/<slug:slug>/", project_page, name="project-page"),
 
     # Rendu serveur des pages statiques (À propos, Mentions légales, …) via le
-    # template Wagtail natif. Route explicite par slug : on ne réactive PAS
-    # encore le catch-all Wagtail global (Phase 5) pour ne pas exposer les
-    # pages blog/projets/home qui n'ont pas encore de template. Placée après
-    # toutes les routes /api/ et /admin/ pour ne pas les masquer.
+    # template Wagtail natif. Route explicite par slug, placée après toutes
+    # les routes /api/ et /admin/ pour ne pas les masquer.
     path("<slug:slug>/", static_page_html, name="static-page-html"),
 
-    # Catch-all Wagtail (page tree) — désactivé : Next.js gère encore le rendu
-    # des sections non migrées. Réactivation prévue en Phase 5 (bascule
-    # monolithe), une fois tous les templates en place.
-    # path("", include(wagtail_urls)),
+    # Catch-all Wagtail (page tree) — RÉACTIVÉ (Phase 5a). Désormais tous les
+    # templates sont en place : Wagtail sert nativement l'arbre de pages à
+    # leurs URLs. Les routes explicites ci-dessus restent prioritaires (résultat
+    # identique) et seront retirées en Phase 5b une fois Traefik basculé sur
+    # Django. Doit rester en DERNIER (il matche tout).
+    path("", include(wagtail_urls)),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
## Résumé

Première étape de la Phase 5 (#158, épic #152), **purement additive et sans impact public**.

Réactive `path("", include(wagtail_urls))` dans `config/urls.py` : Wagtail sert désormais nativement tout l'arbre de pages à leurs URLs. Tous les templates étant en place (Phases 1-4), c'est sans risque.

## Détails

- Les routes explicites (home `/`, `contact/`, `blog/...`, `projets/...`, pages statiques `<slug>/`) restent **prioritaires** au-dessus du catch-all → comportement **inchangé** sur le service Django.
- Elles seront retirées en **Phase 5b**, une fois Traefik basculé sur Django (les pages Wagtail passeront alors par le catch-all ; seule `/contact/` restera explicite, n'étant pas une page Wagtail).
- Aucun impact sur le trafic public : il est toujours routé vers Next.js par Traefik. La bascule Traefik est une étape ops distincte, à faire **après** vérification en prod.

## Tests

Suite backend : **154 passants** (aucune régression).

https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF)_