### PR TITLE
Phase 5 (bascule Traefik) — Django catch-all en prod, Next.js en secours

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,15 +10,18 @@
 #   - Reverse proxy Traefik EXTERNE (déjà déployé sur le VPS) qui gère TLS
 #     via Let's Encrypt et l'entrypoint websecure
 #   - PAS de nginx ni de certbot dans ce compose
-#   - Routing :
-#       https://culturall-website.nickorp.com/admin   → django  (Wagtail admin)
-#       https://culturall-website.nickorp.com/api     → django  (DRF API)
-#       https://culturall-website.nickorp.com/static  → django  (servi via whitenoise)
-#       https://culturall-website.nickorp.com/        → nextjs  (catch-all front)
-#       https://cultur-all.org/{admin,api,static}     → django  (domaine alternatif)
-#       https://cultur-all.org/                       → nextjs  (domaine alternatif)
+#   - Routing (Phase 5 — bascule monolithe) :
+#       https://culturall-website.nickorp.com/        → django  (catch-all, rendu Wagtail)
+#       https://cultur-all.org/                       → django  (domaine alternatif)
 #       https://www.cultur-all.org/*                  → 301 redirect vers https://cultur-all.org/*
 #       https://media.cultur-all.org/                 → minio   (médias S3-compatible)
+#
+#     Le service `nextjs` reste déployé en SECOURS DORMANT : son routeur
+#     `-front` est en priorité 10, alors que le routeur Django `-back` est en
+#     priorité 100 et capte tout le trafic. Pour revenir à Next.js (rollback),
+#     restaurer la règle PathPrefix(/admin|/api|/static) sur le routeur `-back`
+#     et redéployer. Next.js et son routeur seront supprimés en Phase 5b une
+#     fois la bascule validée en prod.
 #
 # Placeholders à remplacer :
 #   culturall-website.nickorp.com            : domaine principal de l'app (ex: studio.example.com)
@@ -55,16 +58,20 @@ services:
       - "traefik.enable=true"
       - "traefik.docker.network=n8n-traefik_default"
 
-      # Routeur backend — admin/api/static (Django + Wagtail + whitenoise)
-      - "traefik.http.routers.culturall-website-back.rule=(Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)) && (PathPrefix(`/admin`) || PathPrefix(`/api`) || PathPrefix(`/static`))"
+      # Routeur backend — CATCH-ALL (Django/Wagtail sert tout le site, y compris
+      # /admin, /api, /static via whitenoise). Priorité 100 > 10 du routeur
+      # `-front` (Next.js), donc Django capte l'intégralité du trafic ; Next
+      # reste en secours dormant. Rollback : ré-ajouter
+      # `&& (PathPrefix(/admin) || PathPrefix(/api) || PathPrefix(/static))`.
+      - "traefik.http.routers.culturall-website-back.rule=Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)"
       - "traefik.http.routers.culturall-website-back.entrypoints=websecure"
       - "traefik.http.routers.culturall-website-back.tls=true"
       - "traefik.http.routers.culturall-website-back.tls.certresolver=myresolver"
       - "traefik.http.routers.culturall-website-back.priority=100"
       - "traefik.http.services.culturall-website-back.loadbalancer.server.port=8000"
 
-      # Redirect HTTP → HTTPS pour le backend
-      - "traefik.http.routers.culturall-website-back-http.rule=(Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)) && (PathPrefix(`/admin`) || PathPrefix(`/api`) || PathPrefix(`/static`))"
+      # Redirect HTTP → HTTPS pour le backend (catch-all, cf. routeur ci-dessus)
+      - "traefik.http.routers.culturall-website-back-http.rule=Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)"
       - "traefik.http.routers.culturall-website-back-http.entrypoints=web"
       - "traefik.http.routers.culturall-website-back-http.middlewares=culturall-website-redirect-to-https"
     restart: always
@@ -86,7 +93,10 @@ services:
       - "traefik.enable=true"
       - "traefik.docker.network=n8n-traefik_default"
 
-      # Routeur frontend — catch-all (priorité plus basse que /admin /api /static)
+      # Routeur frontend — SECOURS DORMANT depuis la bascule monolithe : même
+      # règle Host que `-back` mais priorité 10 < 100, donc ne reçoit aucun
+      # trafic tant que Django est up. Conservé pour rollback rapide ; supprimé
+      # en Phase 5b.
       - "traefik.http.routers.culturall-website-front.rule=Host(`culturall-website.nickorp.com`) || Host(`cultur-all.org`)"
       - "traefik.http.routers.culturall-website-front.entrypoints=websecure"
       - "traefik.http.routers.culturall-website-front.tls=true"


### PR DESCRIPTION
## Résumé

**Cutover Traefik** : bascule le trafic public de Next.js vers Django (rendu Wagtail côté serveur). Étape de la Phase 5 (#158), à déployer **après** la PR 5a (#164) et **après vérification que `require_authentication` est désactivé**.

## Changement

Règle du routeur `culturall-website-back` élargie de `Host && PathPrefix(/admin|/api|/static)` à `Host(...)` seul (routeurs HTTPS + HTTP). Django (priorité 100) capte tout ; le routeur `-front` Next.js (priorité 10) devient **dormant**.

Le service `nextjs` reste déployé en **secours** → rollback immédiat possible.

## ⚠️ Pré-requis avant merge/déploiement
1. PR 5a (#164) mergée et déployée (catch-all Wagtail actif).
2. **Paramètres du site → `require_authentication = False`** — sinon `LoginRequiredMiddleware` protégerait tout le site public.

## Vérifications post-bascule (domaine public)
- `/`, `/blog/` (+ filtre tag HTMX), `/blog/<slug>/`, `/projets/` (+ filtre), `/projets/<slug>/` (vidéo), `/a-propos/`, `/mentions-legales/`, `/contact/` (HTMX).
- `/admin/`, `/static/css/main.css` (200), images (depuis `media.cultur-all.org`), header Alpine, `www.` → 301 apex.

## Rollback
Restaurer `&& (PathPrefix(/admin) || PathPrefix(/api) || PathPrefix(/static))` sur le routeur `-back` et redéployer → trafic public de retour sur Next.js (jamais arrêté).

## Suite
Une fois validé en prod → **PR 5b** : suppression de `frontend/`, du service `nextjs` + routeur `-front`, de l'API JSON/headless, des routes explicites redondantes, CI + doc.

https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmbZDPBWoc7AqBK5ju23UF)_