### PR TITLE
Centrer le contenu de la page de contact

### DIFF
--- a/backend/home/templates/home/contact_page.html
+++ b/backend/home/templates/home/contact_page.html
@@ -3,7 +3,7 @@
 {% block title %}Contact — Cultur'all{% endblock %}
 
 {% block content %}
-<main class="page">
+<main class="page page--centered">
   <h1>Contact</h1>
   <p>Pour toute question ou proposition, n'hésitez pas à nous contacter.</p>
 

--- a/backend/static/css/main.css
+++ b/backend/static/css/main.css
@@ -143,6 +143,11 @@ body {
   line-height: 1.7;
 }
 
+/* Contenu centré (page de contact) */
+.page--centered {
+  text-align: center;
+}
+
 /* Contact form */
 .contact-form {
   max-width: 640px;
@@ -150,6 +155,12 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.page--centered .contact-form {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: left;
 }
 
 .contact-field {
@@ -218,6 +229,10 @@ body {
 .contact-submit:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.page--centered .contact-submit {
+  align-self: center;
 }
 
 /* Under construction page */


### PR DESCRIPTION
## Objectif

Centrer le contenu de la page de contact, actuellement entièrement aligné à gauche.

## Changements

- Ajout d'une classe modificatrice `page--centered` sur le `<main>` de la page de contact.
- Styles **ciblés uniquement sur cette page** (la classe `.page` est partagée par d'autres pages — projets, blog, pages statiques — et n'est donc pas modifiée) :
  - Titre, paragraphe d'intro et message de succès centrés.
  - Formulaire centré horizontalement (`margin: auto`), avec ses **champs conservés alignés à gauche** (convention de lisibilité des labels/saisies).
  - Bouton « Envoyer » centré.

## Notes

- Aucune modification de comportement côté serveur.
- Périmètre limité au CSS + une classe sur le template.

https://claude.ai/code/session_01LUJ3JdEmNgr6FDLkLskbyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUJ3JdEmNgr6FDLkLskbyf)_