### PR TITLE
Anti-bots : Cloudflare Turnstile sur le formulaire de contact

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ CSRF_TRUSTED_ORIGINS=
 # URL-encode (^ → %5E, # → %23, @ → %40, : → %3A, / → %2F).
 DATABASE_URL=postgres://app_user:app_pass@postgres:5432/app_db
 
+# ─── Cloudflare Turnstile (anti-bots du formulaire de contact) ─
+# Laisser vide en dev/CI : la vérification est alors désactivée.
+# En prod, renseigner les deux clés depuis le dashboard Cloudflare Turnstile.
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+
 # ─── PostgreSQL ────────────────────────────────────────────────
 POSTGRES_DB=app_db
 POSTGRES_USER=app_user

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -18,6 +18,12 @@ CSRF_TRUSTED_ORIGINS = [
     o.strip() for o in os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(",") if o.strip()
 ]
 
+# ─── Cloudflare Turnstile (anti-bots du formulaire de contact) ─
+# Si la clé secrète n'est pas renseignée (dev, tests, CI), la vérification
+# est désactivée afin de ne pas bloquer les environnements sans clés.
+TURNSTILE_SITE_KEY = os.environ.get("TURNSTILE_SITE_KEY", "")
+TURNSTILE_SECRET_KEY = os.environ.get("TURNSTILE_SECRET_KEY", "")
+
 # ─── Apps ──────────────────────────────────────────────────────
 INSTALLED_APPS = [
     "blog",
@@ -82,6 +88,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "wagtail.contrib.settings.context_processors.settings",
+                "home.context_processors.turnstile",
             ],
         },
     },

--- a/backend/home/context_processors.py
+++ b/backend/home/context_processors.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+
+
+def turnstile(request):
+    """Expose la clé publique Turnstile aux templates (chaîne vide si non configurée)."""
+    return {"TURNSTILE_SITE_KEY": settings.TURNSTILE_SITE_KEY}

--- a/backend/home/templates/home/_contact_form.html
+++ b/backend/home/templates/home/_contact_form.html
@@ -32,5 +32,12 @@
     {% if form.message.errors %}<span class="contact-error">{{ form.message.errors.0 }}</span>{% endif %}
   </div>
 
+  {% if TURNSTILE_SITE_KEY %}
+  <div class="cf-turnstile"
+       data-sitekey="{{ TURNSTILE_SITE_KEY }}"
+       data-theme="dark"
+       data-language="fr"></div>
+  {% endif %}
+
   <button type="submit" class="contact-submit">Envoyer</button>
 </form>

--- a/backend/home/templates/home/contact_page.html
+++ b/backend/home/templates/home/contact_page.html
@@ -2,6 +2,26 @@
 
 {% block title %}Contact — Cultur'all{% endblock %}
 
+{% block extra_head %}
+  {% if TURNSTILE_SITE_KEY %}
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
+  <script>
+    // Le rendu implicite ne s'applique qu'au chargement initial. Après un swap
+    // HTMX (formulaire ré-affiché avec ses erreurs), le widget est neuf : on le
+    // (re)rend explicitement.
+    document.addEventListener('htmx:afterSwap', function () {
+      if (!window.turnstile) return;
+      document.querySelectorAll('.cf-turnstile').forEach(function (el) {
+        if (!el.dataset.rendered) {
+          window.turnstile.render(el);
+          el.dataset.rendered = 'true';
+        }
+      });
+    });
+  </script>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 <main class="page">
   <h1>Contact</h1>

--- a/backend/home/tests/test_contact.py
+++ b/backend/home/tests/test_contact.py
@@ -1,7 +1,9 @@
 import pytest
-from django.test import Client
+from django.test import Client, override_settings
 
+from home import turnstile as turnstile_module
 from home.models import ContactSubmission
+from home.turnstile import verify_turnstile
 
 pytestmark = pytest.mark.django_db
 
@@ -89,6 +91,71 @@ class TestContactPageView:
 
     def test_head_allowed(self, client: Client):
         assert client.head(self.url).status_code == 200
+
+
+class TestContactTurnstile:
+    """Protection anti-bots Cloudflare Turnstile du formulaire de contact."""
+
+    url = "/contact/"
+    HTMX = {"HTTP_HX_REQUEST": "true"}
+
+    valid_payload = {
+        "name": "Alice",
+        "email": "alice@example.com",
+        "subject": "Question",
+        "message": "Bonjour, je souhaite en savoir plus.",
+    }
+
+    def test_widget_absent_when_site_key_not_configured(self, client: Client):
+        # En dev/tests la clé n'est pas configurée → pas de widget.
+        body = client.get(self.url).content.decode()
+        assert "cf-turnstile" not in body
+
+    @override_settings(TURNSTILE_SITE_KEY="1x00000000000000000000AA")
+    def test_widget_rendered_when_site_key_configured(self, client: Client):
+        body = client.get(self.url).content.decode()
+        assert "cf-turnstile" in body
+        assert "1x00000000000000000000AA" in body
+        assert "challenges.cloudflare.com" in body
+
+    @override_settings(TURNSTILE_SECRET_KEY="secret")
+    def test_post_rejected_when_verification_fails(self, client: Client, monkeypatch):
+        monkeypatch.setattr("home.views.verify_turnstile", lambda *a, **k: False)
+        resp = client.post(self.url, self.valid_payload, **self.HTMX)
+
+        assert resp.status_code == 200
+        body = resp.content.decode()
+        assert "anti-robot" in body
+        assert 'class="contact-form"' in body
+        assert ContactSubmission.objects.count() == 0
+
+    @override_settings(TURNSTILE_SECRET_KEY="secret")
+    def test_post_accepted_when_verification_succeeds(self, client: Client, monkeypatch):
+        monkeypatch.setattr("home.views.verify_turnstile", lambda *a, **k: True)
+        resp = client.post(self.url, self.valid_payload, **self.HTMX)
+
+        assert resp.status_code == 200
+        assert "contact-success" in resp.content.decode()
+        assert ContactSubmission.objects.count() == 1
+
+
+class TestVerifyTurnstileHelper:
+    """Logique de court-circuit du helper (aucun appel réseau)."""
+
+    @override_settings(TURNSTILE_SECRET_KEY="")
+    def test_disabled_when_secret_absent(self):
+        # Sans clé secrète, la vérification est désactivée (toujours True).
+        assert verify_turnstile("") is True
+        assert verify_turnstile("n-importe-quoi") is True
+
+    @override_settings(TURNSTILE_SECRET_KEY="secret")
+    def test_empty_token_fails_without_network(self, monkeypatch):
+        # Un jeton vide échoue immédiatement, sans toucher au réseau.
+        def _boom(*a, **k):  # pragma: no cover - ne doit jamais être appelé
+            raise AssertionError("urlopen ne doit pas être appelé pour un jeton vide")
+
+        monkeypatch.setattr(turnstile_module.request, "urlopen", _boom)
+        assert verify_turnstile("") is False
 
 
 class TestContactSubmissionModel:

--- a/backend/home/turnstile.py
+++ b/backend/home/turnstile.py
@@ -1,0 +1,41 @@
+"""Vérification serveur des jetons Cloudflare Turnstile.
+
+Si `TURNSTILE_SECRET_KEY` n'est pas configurée (dev, tests, CI), la
+vérification est considérée comme réussie afin de ne pas bloquer les
+environnements sans clés. En production, renseigner les variables
+d'environnement `TURNSTILE_SITE_KEY` et `TURNSTILE_SECRET_KEY`.
+"""
+
+import json
+from urllib import error, parse, request
+
+from django.conf import settings
+
+SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+
+def verify_turnstile(token, remoteip=None, timeout=5):
+    """Retourne True si le jeton est valide (ou si la clé secrète n'est pas configurée).
+
+    Court-circuite sans appel réseau quand la clé est absente (vérification
+    désactivée) ou quand le jeton est vide (échec immédiat). Toute erreur
+    réseau ou réponse illisible est traitée comme un échec.
+    """
+    secret = settings.TURNSTILE_SECRET_KEY
+    if not secret:
+        return True
+    if not token:
+        return False
+
+    payload = {"secret": secret, "response": token}
+    if remoteip:
+        payload["remoteip"] = remoteip
+
+    data = parse.urlencode(payload).encode()
+    try:
+        with request.urlopen(SITEVERIFY_URL, data=data, timeout=timeout) as resp:
+            result = json.loads(resp.read().decode())
+    except (error.URLError, ValueError, TimeoutError):
+        return False
+
+    return bool(result.get("success"))

--- a/backend/home/views.py
+++ b/backend/home/views.py
@@ -4,6 +4,15 @@ from django.views.decorators.http import require_http_methods, require_safe
 
 from .forms import ContactForm
 from .models import ContactSubmission, HomePage
+from .turnstile import verify_turnstile
+
+
+def _client_ip(request):
+    """IP de l'appelant en tenant compte d'un éventuel proxy (X-Forwarded-For)."""
+    forwarded = request.META.get("HTTP_X_FORWARDED_FOR")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR")
 
 
 @require_safe
@@ -25,11 +34,19 @@ def contact_page(request):
     """
     if request.method == "POST":
         form = ContactForm(request.POST)
-        if form.is_valid():
+        form_valid = form.is_valid()
+        human = verify_turnstile(
+            request.POST.get("cf-turnstile-response", ""), _client_ip(request)
+        )
+
+        if form_valid and human:
             ContactSubmission.objects.create(**form.cleaned_data)
             if request.htmx:
                 return render(request, "home/_contact_success.html")
             return render(request, "home/contact_page.html", {"success": True})
+
+        if not human:
+            form.add_error(None, "La vérification anti-robot a échoué. Merci de réessayer.")
 
         if request.htmx:
             return render(request, "home/_contact_form.html", {"form": form})

--- a/backend/templates/base.html
+++ b/backend/templates/base.html
@@ -14,6 +14,7 @@
   <script src="{% static 'js/htmx.min.js' %}" defer></script>
   <script src="{% static 'js/site.js' %}" defer></script>
   <script src="{% static 'js/alpine.min.js' %}" defer></script>
+  {% block extra_head %}{% endblock %}
 </head>
 <body>
   {% include "_header.html" %}

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -20,6 +20,8 @@ services:
       - DJANGO_SECRET_KEY
       - DEBUG
       - ALLOWED_HOSTS
+      - TURNSTILE_SITE_KEY
+      - TURNSTILE_SECRET_KEY
       - DATABASE_URL
       - MINIO_ROOT_USER
       - MINIO_ROOT_PASSWORD


### PR DESCRIPTION
## Objectif

Protéger le formulaire de contact contre les bots via **Cloudflare Turnstile** (respectueux de la vie privée, compatible RGPD — pertinent pour un site UE).

## Changements

**Affichage**
- Widget Turnstile injecté dans le formulaire, **rendu conditionnel** selon la présence de `TURNSTILE_SITE_KEY` (thème sombre, langue française).
- Script Turnstile chargé uniquement sur la page de contact (nouveau bloc `extra_head` dans `base.html`).
- Re-rendu du widget après un swap HTMX (sinon il reste vide quand le formulaire est ré-affiché avec ses erreurs).

**Serveur**
- `home/turnstile.py` : vérification du jeton via l'API `siteverify` de Cloudflare, en **`urllib` (aucune nouvelle dépendance)**. Toute erreur réseau = échec.
- La vue valide le jeton ; en cas d'échec, le formulaire est ré-affiché avec le message « La vérification anti-robot a échoué ».
- **Vérification désactivée si `TURNSTILE_SECRET_KEY` n'est pas configurée** (dev / CI / tests) → aucun blocage dans ces environnements.

**Configuration**
- `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` lues depuis l'environnement, exposées aux templates via un context processor, documentées dans `.env.example` et transmises au conteneur `django` (docker-compose).

## Tests

- Widget conditionnel (présent/absent selon la clé publique).
- POST rejeté / accepté selon le résultat de la vérification.
- Court-circuit du helper sans appel réseau (clé absente → OK ; jeton vide → échec).
- Suite complète : 104 tests verts.

## ⚠️ Point d'attention

Turnstile nécessite **JavaScript**. Une fois les clés activées en production, les utilisateurs sans JS ne pourront plus soumettre le formulaire (pas de jeton → rejet) — compromis inhérent à tout captcha JS. Si l'on veut préserver le fallback sans-JS, on peut ajouter un **honeypot** en complément (qui, lui, fonctionne sans JS).

## Activation en production

1. Créer un widget sur le dashboard Cloudflare Turnstile (gratuit) → *site key* + *secret key*.
2. Renseigner `TURNSTILE_SITE_KEY` et `TURNSTILE_SECRET_KEY` dans `.env.prod`.

https://claude.ai/code/session_01LUJ3JdEmNgr6FDLkLskbyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUJ3JdEmNgr6FDLkLskbyf)_