### PR TITLE
fix(deploy): collecter les statics avant de démarrer le conteneur

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -61,6 +61,17 @@ jobs:
             echo "==> Pulling pre-built images..."
             $COMPOSE_CMD pull django
 
+            # Collecte des statics AVANT de (re)démarrer le conteneur applicatif.
+            # WhiteNoise (CompressedManifestStaticFilesStorage) lit le manifest
+            # staticfiles.json et indexe STATIC_ROOT au démarrage du process.
+            # Comme /app/staticfiles est un volume persistant, lancer
+            # collectstatic APRÈS le démarrage faisait servir le manifest du
+            # déploiement précédent (CSS/JS périmés) jusqu'au prochain redémarrage.
+            # On collecte donc dans le volume via un conteneur jetable (nouvelle
+            # image), puis on (re)crée le service qui démarre sur un manifest frais.
+            echo "==> Collecting static files (avant démarrage)..."
+            $COMPOSE_CMD run --rm --no-deps django python manage.py collectstatic --noinput
+
             echo "==> Restarting services with new images..."
             # nginx est désactivé en prod (Traefik fait le reverse proxy).
             # --remove-orphans nettoie les conteneurs de services retirés du
@@ -69,9 +80,6 @@ jobs:
 
             echo "==> Running Django/Wagtail migrations..."
             $COMPOSE_CMD exec -T django python manage.py migrate --noinput
-
-            echo "==> Collecting static files..."
-            $COMPOSE_CMD exec -T django python manage.py collectstatic --noinput
 
             echo "==> Updating Wagtail search index..."
             $COMPOSE_CMD exec -T django python manage.py update_index || true


### PR DESCRIPTION
## Problème

En production, le site servait du **CSS/JS périmé** : le HTML déployé était à jour (ex. `<main class="page page--centered">`) mais le fichier `main.<hash>.css` servi ne contenait pas les nouvelles règles. Le site était en permanence **« un déploiement en retard »** sur les fichiers statiques.

## Cause racine

- `STORAGES.staticfiles = whitenoise.storage.CompressedManifestStaticFilesStorage`.
- `/app/staticfiles` est un **volume persistant** (`static_files`).
- WhiteNoise charge le manifest `staticfiles.json` et indexe `STATIC_ROOT` **au démarrage** du process gunicorn.

Dans `deploy-prod.yml`, l'ordre était :
1. `up -d --force-recreate django` → le conteneur démarre et lit le manifest **du déploiement précédent** (présent dans le volume).
2. *puis* `collectstatic` écrit les nouveaux fichiers (nouveau hash) dans le volume.

Résultat : le process tourne déjà avec l'ancien manifest en mémoire ; `{% static %}` pointe vers l'ancien hash et WhiteNoise sert l'ancien fichier jusqu'au prochain redémarrage.

## Correctif

`collectstatic` s'exécute désormais **avant** la (re)création du service, dans un conteneur jetable utilisant la nouvelle image :

```bash
$COMPOSE_CMD run --rm --no-deps django python manage.py collectstatic --noinput
$COMPOSE_CMD up -d --force-recreate --no-build --remove-orphans django minio postgres
```

Le conteneur applicatif démarre ainsi toujours sur un manifest frais. `migrate` et `update_index` restent après le démarrage (ils nécessitent les services up).

## Vérification

Une fois mergé, `build-images.yml` rebuild + redéploie automatiquement, ce qui validera le correctif et corrigera la prod par la même occasion.

https://claude.ai/code/session_01LUJ3JdEmNgr6FDLkLskbyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUJ3JdEmNgr6FDLkLskbyf)_